### PR TITLE
Migrate database on app start

### DIFF
--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -1,0 +1,59 @@
+package migrate
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jackc/tern/v2/migrate"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/riverqueue/river/rivermigrate"
+
+	"github.com/cloud-gov/billing/sql/migrations"
+)
+
+// Migrate migrates the database to the latest migrations for the application and the River queue. It is idempotent.
+func Migrate(ctx context.Context, pool *pgxpool.Pool) error {
+	err := migrateRiver(ctx, pool)
+	if err != nil {
+		return err
+	}
+
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		return err
+	}
+
+	err = migrateTern(ctx, conn.Conn())
+	return err
+}
+
+// migrateRiver uses the rivermigrate package to run "up" migrations for the River queue.
+func migrateRiver(ctx context.Context, conn *pgxpool.Pool) error {
+	migrator, err := rivermigrate.New(riverpgxv5.New(conn), nil)
+	if err != nil {
+		return err
+	}
+	// If already migrated to latest, this is a noop.
+	_, err = migrator.Migrate(ctx, rivermigrate.DirectionUp, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// migrateTern uses the tern package to execute "up" migrations for the billing service schema.
+func migrateTern(ctx context.Context, conn *pgx.Conn) error {
+	m, err := migrate.NewMigrator(context.Background(), conn, "my_schema_version")
+	if err != nil {
+		return err
+	}
+	err = m.LoadMigrations(migrations.FS)
+	if err != nil {
+		return err
+	}
+	// If already migrated to latest, this is a noop.
+	err = m.Migrate(ctx)
+	return err
+
+}

--- a/sql/migrations/embed.go
+++ b/sql/migrations/embed.go
@@ -1,0 +1,7 @@
+// The migrations package exists solely to embed the .sql migrations so the application can access them.
+package migrations
+
+import "embed"
+
+//go:embed *
+var FS embed.FS


### PR DESCRIPTION
## Changes proposed in this pull request:

This is required for https://github.com/cloud-gov/product/issues/3310. We need to run the migrations before the web server and River start, both initially and upon new migrations. Concourse doesn't have credentials to access to the brokered database, so migrations can't be run there. CF recommends using Tasks for one-off jobs, but there is no CF Terraform module for Tasks, so we'd have to write a script and further customize the CI pipeline.

Fortunately, both River and Tern are written in Go and make their migration packages public. This code uses their Go bindings instead of their CLI tools to run their respective migrations on app start.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None new.