### PR TITLE
Add admin API, protected by JWT auth and new scopes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,14 @@ watch:
 		sleep 0.5 ; \
 	done
 
+.PHONY: watchtest
+watchtest:
+	@echo "Running unit tests every time .go files change. Press ctrl+c *twice* to exit, or once to rebuild."
+	@while true; do \
+		sleep 0.5 ; \
+		set -a; source docker.env; set +a; find . -type f -name '*.go' | entr -d go test ./... ; \
+	done
+
 .PHONY: clean
 clean: db-down
 	go clean
@@ -66,3 +74,7 @@ migrate: db-init
 .PHONY: db-reset
 db-reset: db-drop db-init migrate
 	@echo "Database reset. Restart app to reconnect."
+
+.PHONY: psql
+psql:
+	@set -a; source docker.env; set +a; psql

--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ As of writing, the application uses the local user's Cloud Foundry session to au
 
 Note that table name `schema_version` is reserved by tern for tracking migration status.
 
+### Dependencies
+
+Why does this project use the packages that it does?
+
+- `jackc/pgx` is used because sqlc supports it, and unlike `database/sql` it supports COPY and the postgres binary protocol, which is faster than the SQL textual protocol.
+- `jackc/tern` is used for migrations because we already use another package by `jackc`, `pgx`, and sqlc supports it.
+- `coreos/go-oidc` is used for JWT validation over alternatives because it is maintained by a reputable organization (CoreOS) and supports JWKS discovery.
+
 ### Environment variables
 
 - Postgres and AWS use their conventional environment variables for configuration. See [Postgres docs](https://www.postgresql.org/docs/current/libpq-envars.html) and [AWS docs](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html).

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -39,6 +39,7 @@ jobs:
             CF_API_URL: ((dev-cf-api-url))
             CF_CLIENT_ID: ((billing-cf-client-id))
             CF_CLIENT_SECRET: ((billing-cf-client-secret-development))
+            OIDC_ISSUER: ((oidc-issuer-development))
           TF_VAR_org_name: ((org-name))
           TF_VAR_path: ../../.. # terraform-templates, relative to TEMPLATE_SUBDIR, where terraform executes
           TF_VAR_space_name: ((space-name))

--- a/ci/terraform/stack/variables.tf
+++ b/ci/terraform/stack/variables.tf
@@ -31,5 +31,6 @@ variable "environment" {
     CF_API_URL       = string
     CF_CLIENT_ID     = string
     CF_CLIENT_SECRET = string
+    OIDC_ISSUER      = string
   })
 }

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,10 @@ go 1.24
 
 require (
 	github.com/cloudfoundry/go-cfclient/v3 v3.0.0-alpha.12.0.20250605163211-41fbb9ee824a
+	github.com/coreos/go-oidc/v3 v3.14.1
 	github.com/go-chi/chi/v5 v5.2.1
 	github.com/jackc/pgx/v5 v5.7.5
+	github.com/jackc/tern/v2 v2.3.3
 	github.com/riverqueue/river v0.23.1
 	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.23.1
 	github.com/robfig/cron/v3 v3.0.1
@@ -23,6 +25,7 @@ require (
 	github.com/cubicdaiya/gonp v1.0.4 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/fatih/structtag v1.2.0 // indirect
+	github.com/go-jose/go-jose/v4 v4.0.5 // indirect
 	github.com/go-sql-driver/mysql v1.9.2 // indirect
 	github.com/google/cel-go v0.24.1 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
@@ -30,7 +33,6 @@ require (
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
-	github.com/jackc/tern/v2 v2.3.3 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/lmittmann/tint v1.1.1 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/cubicdaiya/gonp v1.0.4 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/fatih/structtag v1.2.0 // indirect
+	github.com/go-chi/httplog/v3 v3.2.2 // indirect
 	github.com/go-jose/go-jose/v4 v4.0.5 // indirect
 	github.com/go-sql-driver/mysql v1.9.2 // indirect
 	github.com/google/cel-go v0.24.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24
 require (
 	github.com/cloudfoundry/go-cfclient/v3 v3.0.0-alpha.12.0.20250605163211-41fbb9ee824a
 	github.com/coreos/go-oidc/v3 v3.14.1
-	github.com/go-chi/chi/v5 v5.2.1
+	github.com/go-chi/chi/v5 v5.2.2
 	github.com/jackc/pgx/v5 v5.7.5
 	github.com/jackc/tern/v2 v2.3.3
 	github.com/riverqueue/river v0.23.1

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/cloudfoundry/go-cfclient/v3 v3.0.0-alpha.12.0.20250605163211-41fbb9ee824a
 	github.com/coreos/go-oidc/v3 v3.14.1
 	github.com/go-chi/chi/v5 v5.2.2
+	github.com/go-chi/httplog/v3 v3.2.2
 	github.com/jackc/pgx/v5 v5.7.5
 	github.com/jackc/tern/v2 v2.3.3
 	github.com/riverqueue/river v0.23.1
@@ -25,7 +26,6 @@ require (
 	github.com/cubicdaiya/gonp v1.0.4 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/fatih/structtag v1.2.0 // indirect
-	github.com/go-chi/httplog/v3 v3.2.2 // indirect
 	github.com/go-jose/go-jose/v4 v4.0.5 // indirect
 	github.com/go-sql-driver/mysql v1.9.2 // indirect
 	github.com/google/cel-go v0.24.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/go-chi/chi/v5 v5.2.1 h1:KOIHODQj58PmL80G2Eak4WdvUzjSJSm0vG72crDCqb8=
 github.com/go-chi/chi/v5 v5.2.1/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
+github.com/go-chi/httplog/v3 v3.2.2 h1:G0oYv3YYcikNjijArHFUlqfR78cQNh9fGT43i6StqVc=
+github.com/go-chi/httplog/v3 v3.2.2/go.mod h1:N/J1l5l1fozUrqIVuT8Z/HzNeSy8TF2EFyokPLe6y2w=
 github.com/go-jose/go-jose/v4 v4.0.5 h1:M6T8+mKZl/+fNNuFHvGIzDz7BTLQPIounk/b9dw3AaE=
 github.com/go-jose/go-jose/v4 v4.0.5/go.mod h1:s3P1lRrkT8igV8D9OjyL4WRyHvjB6a4JSllnOrmmBOA=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
-github.com/go-chi/chi/v5 v5.2.1 h1:KOIHODQj58PmL80G2Eak4WdvUzjSJSm0vG72crDCqb8=
-github.com/go-chi/chi/v5 v5.2.1/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
+github.com/go-chi/chi/v5 v5.2.2 h1:CMwsvRVTbXVytCk1Wd72Zy1LAsAh9GxMmSNWLHCG618=
+github.com/go-chi/chi/v5 v5.2.2/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
 github.com/go-chi/httplog/v3 v3.2.2 h1:G0oYv3YYcikNjijArHFUlqfR78cQNh9fGT43i6StqVc=
 github.com/go-chi/httplog/v3 v3.2.2/go.mod h1:N/J1l5l1fozUrqIVuT8Z/HzNeSy8TF2EFyokPLe6y2w=
 github.com/go-jose/go-jose/v4 v4.0.5 h1:M6T8+mKZl/+fNNuFHvGIzDz7BTLQPIounk/b9dw3AaE=

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/cloudfoundry/go-cfclient/v3 v3.0.0-alpha.12.0.20250605163211-41fbb9ee
 github.com/cloudfoundry/go-cfclient/v3 v3.0.0-alpha.12.0.20250605163211-41fbb9ee824a/go.mod h1:+sY77PKx6xxDyApQ07webuPs80UMefAOTMPFuwXUerM=
 github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0 h1:sDMmm+q/3+BukdIpxwO365v/Rbspp2Nt5XntgQRXq8Q=
 github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0/go.mod h1:4Zcjuz89kmFXt9morQgcfYZAYZ5n8WHjt81YYWIwtTM=
+github.com/coreos/go-oidc/v3 v3.14.1 h1:9ePWwfdwC4QKRlCXsJGou56adA/owXczOzwKdOumLqk=
+github.com/coreos/go-oidc/v3 v3.14.1/go.mod h1:HaZ3szPaZ0e4r6ebqvsLWlk2Tn+aejfmrfah6hnSYEU=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/cubicdaiya/gonp v1.0.4 h1:ky2uIAJh81WiLcGKBVD5R7KsM/36W6IqqTy6Bo6rGws=
 github.com/cubicdaiya/gonp v1.0.4/go.mod h1:iWGuP/7+JVTn02OWhRemVbMmG1DOUnmrGTYYACpOI0I=
@@ -34,6 +36,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/go-chi/chi/v5 v5.2.1 h1:KOIHODQj58PmL80G2Eak4WdvUzjSJSm0vG72crDCqb8=
 github.com/go-chi/chi/v5 v5.2.1/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
+github.com/go-jose/go-jose/v4 v4.0.5 h1:M6T8+mKZl/+fNNuFHvGIzDz7BTLQPIounk/b9dw3AaE=
+github.com/go-jose/go-jose/v4 v4.0.5/go.mod h1:s3P1lRrkT8igV8D9OjyL4WRyHvjB6a4JSllnOrmmBOA=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=

--- a/internal/api/middleware/auth.go
+++ b/internal/api/middleware/auth.go
@@ -1,0 +1,58 @@
+package middleware
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+)
+
+// ctxKey is the key for accessing Claims data stored in a Context. See Context.Value() docs for explanation.
+var ctxKey struct{}
+
+type Claims struct {
+	Email  string   `json:"email"`
+	Scopes []string `json:"scope"`
+}
+
+func NewHasScope(logger *slog.Logger, verifier *oidc.IDTokenVerifier, scope string) func(http.Handler) http.Handler {
+	return func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ah := r.Header.Get("Authorization")
+			if !strings.HasPrefix(strings.ToLower(ah), "bearer ") {
+				http.Error(w, "missing bearer token", http.StatusUnauthorized)
+				return
+			}
+			raw := strings.TrimSpace(ah[7:]) // len("bearer ")
+
+			idTok, err := verifier.Verify(r.Context(), raw)
+			if err != nil {
+				http.Error(w, "invalid token", http.StatusUnauthorized)
+				return
+			}
+			var c Claims
+			err = idTok.Claims(&c)
+			if err != nil {
+				http.Error(w, "cannot parse claims", http.StatusUnauthorized)
+				return
+			}
+
+			if scope != "" && !slices.Contains(c.Scopes, scope) {
+				http.Error(w, "forbidden", http.StatusForbidden)
+				return
+			}
+
+			rc := r.WithContext(context.WithValue(r.Context(), ctxKey, c))
+
+			h.ServeHTTP(w, rc)
+		})
+	}
+}
+
+func ClaimsFrom(ctx context.Context) (Claims, bool) {
+	c, ok := ctx.Value(ctxKey).(Claims)
+	return c, ok
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,15 +6,17 @@ import (
 )
 
 type Config struct {
-	ApiUrl         string
+	CFApiUrl string
+	// CFClientID is the ID of the client created in UAA with permission to read data from CAPI. Because the billing service is the resource server in the OIDC relationship, it doubles as the audience claim in JWTs.
 	CFClientId     string
 	CFClientSecret string
+	Issuer         string
 }
 
 func New() (Config, error) {
 	c := Config{}
-	c.ApiUrl = os.Getenv("CF_API_URL")
-	if c.ApiUrl == "" {
+	c.CFApiUrl = os.Getenv("CF_API_URL")
+	if c.CFApiUrl == "" {
 		return Config{}, errors.New("reading CF_API_URL")
 	}
 	c.CFClientId = os.Getenv("CF_CLIENT_ID")
@@ -25,6 +27,9 @@ func New() (Config, error) {
 	if c.CFClientSecret == "" {
 		return Config{}, errors.New("reading CF_CLIENT_SECRET")
 	}
-
+	c.Issuer = os.Getenv("OIDC_ISSUER")
+	if c.Issuer == "" {
+		return Config{}, errors.New("reading OIDC_ISSUER")
+	}
 	return c, nil
 }

--- a/internal/jobs/usage.go
+++ b/internal/jobs/usage.go
@@ -81,10 +81,10 @@ func (u *MeasureUsageWorker) Work(ctx context.Context, job *river.Job[MeasureUsa
 }
 
 // NewMeasureUsageWorker stores dependencies required for job execution and returns a new worker.
-func NewMeasureUsageWorker(l *slog.Logger, c *pgxpool.Pool, q dbtx.Querier, r *reader.Reader) (*MeasureUsageWorker, error) {
+func NewMeasureUsageWorker(l *slog.Logger, c *pgxpool.Pool, q dbtx.Querier, r *reader.Reader) *MeasureUsageWorker {
 	logger = l
 	conn = c
 	querier = q
 	rdr = r
-	return &MeasureUsageWorker{}, nil
+	return &MeasureUsageWorker{}
 }

--- a/main.go
+++ b/main.go
@@ -134,6 +134,11 @@ func run(ctx context.Context, out io.Writer) error {
 	}
 
 	logger.Debug("run: starting web server")
+
+	// Admin routes are internal only and served on a different port.
+	adminSrv := server.New("", "8081", api.AdminRoutes(logger, q), logger)
+	go adminSrv.ListenAndServe(ctx)
+
 	srv := server.New("", "8080", api.Routes(logger, cfclient, q, riverc), logger)
 	srv.ListenAndServe(ctx)
 	return nil

--- a/main.go
+++ b/main.go
@@ -139,12 +139,7 @@ func run(ctx context.Context, out io.Writer) error {
 	}
 
 	logger.Debug("run: starting web server")
-
-	// Admin routes are internal only and served on a different port.
-	adminSrv := server.New("", "8081", api.AdminRoutes(logger, q, verifier), logger)
-	go adminSrv.ListenAndServe(ctx)
-
-	srv := server.New("", "8080", api.Routes(logger, cfclient, q, riverc), logger)
+	srv := server.New("", "8080", api.Routes(logger, cfclient, q, riverc, verifier), logger)
 	srv.ListenAndServe(ctx)
 	return nil
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add a new middleware that verifies JWTs and checks if the subject has a configurable scope
- Protected all existing HTTP endpoints with the new middleware, requiring `usage.admin` scope
  - Note that no clients currently request this scope; working on that!
- Various small improvements to Makefile and docs

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Necessary security work as explained in https://github.com/cloud-gov/product/issues/3303. Also related to https://github.com/cloud-gov/product/issues/3304. 