### PR TITLE
Drop unused plugin cache put

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -113,9 +113,6 @@ jobs:
           TF_VAR_org_name: ((org-name))
           TF_VAR_path: ../../.. # terraform-templates, relative to TEMPLATE_SUBDIR, where terraform executes
           TF_VAR_space_name: ((space-name))
-      - put: terraform-plugin-cache
-        params:
-          file: updated-terraform-plugin-cache/cache.tar.gz
 
   - name: terraform-apply-billing-staging
     plan:


### PR DESCRIPTION
## Changes proposed in this pull request:

- See title

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None