### PR TITLE
Prevent multiple builds for each merge

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -13,7 +13,7 @@ jobs:
             trigger: false
           - get: terraform-templates
             resource: terraform-config
-            trigger: true # Changes to the terraform deployment code trigger a rebuild
+            trigger: false
           - get: src
             resource: src
             trigger: true # App code changes trigger a rebuild
@@ -54,10 +54,10 @@ jobs:
             trigger: false
           - get: terraform-templates
             resource: terraform-config
-            trigger: true # Changes to the terraform deployment code trigger a rebuild
+            trigger: false
           - get: src
             resource: src
-            trigger: true # Pipeline changes do not automatically trigger a rebuild
+            trigger: true
             passed: [terraform-plan-billing-development]
           - get: pipeline-tasks
           - get: general-task
@@ -83,10 +83,10 @@ jobs:
             trigger: false
           - get: terraform-templates
             resource: terraform-config
-            trigger: true # Changes to the terraform deployment code trigger a rebuild
+            trigger: false
           - get: src
             resource: src
-            trigger: true # App code changes trigger a rebuild
+            trigger: true
             passed: [terraform-apply-billing-development]
           - get: pipeline-tasks
           - get: general-task
@@ -121,10 +121,10 @@ jobs:
             trigger: false
           - get: terraform-templates
             resource: terraform-config
-            trigger: true # Changes to the terraform deployment code trigger a rebuild
+            trigger: false
           - get: src
             resource: src
-            trigger: true # Pipeline changes do not automatically trigger a rebuild
+            trigger: true
             passed: [terraform-plan-billing-staging]
           - get: pipeline-tasks
           - get: general-task


### PR DESCRIPTION

## Changes proposed in this pull request:

Currently in Concourse, one PR merge kicks off two builds for each job. I think the cause is that two resources (src and terraform-templates) watch the same repo, and both have `trigger: true`. I'm switching to triggering only on `src` because it watches the entire repo tree; `terraform-templates` is intentionally scoped to the `ci/terraform` only.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None.