### PR TITLE
ci: add basic go-build-test github workflow

### DIFF
--- a/.github/workflows/go-build-test.yml
+++ b/.github/workflows/go-build-test.yml
@@ -1,0 +1,30 @@
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
+name: "Go Build & Test"
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+
+      - name: Install dependencies
+        run: go get ./...
+
+      - name: Check formatting
+        run: test -z "$(gofmt -l .)"
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Build
+        run: go build -v .
+
+      - name: Test
+        run: go test -v ./...


### PR DESCRIPTION
## Changes proposed in this pull request:

Checks out code, sets up go, installs deps, checks formatting w/ gofmt, runs go vet, runs build, runs test.

Ideally we'd incorporate Docker and/or Postgres and use the Makefile, but I'm just copying over the simple CI we were using for the GitLab Runner driver.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

- Adds a new CI workflow which means GitHub will be executing some new utilities (`gofmt`, `go vet`) and executing a build & test. 
- It should be ensured that external users cannot run insecure CI/CD workflows.
