### PR TITLE
Fix codeowners to put success and devtools at equal precedence

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-* @cloud-gov/customer-success-squad
-* @cloud-gov/devtools
+* @cloud-gov/customer-success-squad @cloud-gov/devtools


### PR DESCRIPTION
## Changes proposed in this pull request:

- Later lines of the CODEOWNERS get precedence; I intended to allow both teams to do PR reviews.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Fixes PR approval permissions.