### PR TITLE
Add PR job to check Go, SQL code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+# This dockerfile is used for testing in CI only. The image runs in a buildpack in Cloud.gov and is developed locally without docker.
+ARG base_image
+
+FROM ${base_image}
+COPY . /app
+WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-# This dockerfile is used for testing in CI only. The image runs in a buildpack in Cloud.gov and is developed locally without docker.
+# This dockerfile is used for testing in CI only.
+# In Cloud.gov, the app runs in a buildpack instead. For local development, a Docker container is not needed.
 ARG base_image
 
 FROM ${base_image}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,0 @@
-# This dockerfile is used for testing in CI only.
-# In Cloud.gov, the app runs in a buildpack instead. For local development, a Docker container is not needed.
-ARG base_image
-
-FROM ${base_image}
-COPY . /app
-WORKDIR /app

--- a/Makefile
+++ b/Makefile
@@ -131,23 +131,24 @@ test-db:
 	@set -a; source docker.env; PGPORT=5433; set +a; \
 	go test ./... -run TestDB -count=1
 
+# Run from inside a container.
+# Ephemeral database must already be up via docker compose.
 .PHONY: test-db-ci
 test-db-ci:
-	@# Assume the database is up, but not migrated.
 	@# Equivalent to `make db-init`, but for the ephemeral database
 	@# Intended to be run inside a container.
-	@PGDATABASE=postgres \
+	PGDATABASE=postgres \
 	go tool tern migrate --config sql/init/tern.conf --migrations sql/init
 
 	@# Equivalent to `make db-migrate`, but for the ephemeral database.
 	@# Migrate to the latest migration.
-	@go tool tern migrate --config sql/migrations/tern.conf --migrations sql/migrations
+	go tool tern migrate --config sql/migrations/tern.conf --migrations sql/migrations
 	@# Migrate River schema to latest.
-	@go tool river migrate-up
+	go tool river migrate-up
 
 	@echo "Running database tests (TestDB*)..."
 	@# Disable caching with -count=1, since go does not cache bust when .sql files change
-	@go test ./... -run TestDB -count=1
+	go test ./... -run TestDB -count=1
 
 .PHONY: jwt
 jwt:

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,11 @@ SHELL := /bin/bash
 
 .PHONY: db-up
 db-up:
-	docker compose up --detach --wait
+	docker compose up --detach --wait db
 
 .PHONY: db-down
 db-down:
-	docker compose down
+	docker compose down db
 
 .PHONY: gen
 gen: db-up
@@ -135,21 +135,19 @@ test-db:
 test-db-ci:
 	@# Assume the database is up, but not migrated.
 	@# Equivalent to `make db-init`, but for the ephemeral database
-	@set -a; source docker.env; PGDATABASE=postgres PGPORT=5433; set +a; \
+	@# Intended to be run inside a container.
+	@PGDATABASE=postgres \
 	go tool tern migrate --config sql/init/tern.conf --migrations sql/init
 
 	@# Equivalent to `make db-migrate`, but for the ephemeral database.
 	@# Migrate to the latest migration.
-	@set -a; source docker.env; PGPORT=5433; set +a; \
-	go tool tern migrate --config sql/migrations/tern.conf --migrations sql/migrations
+	@go tool tern migrate --config sql/migrations/tern.conf --migrations sql/migrations
 	@# Migrate River schema to latest.
-	@set -a; source docker.env; PGPORT=5433; set +a; \
-	go tool river migrate-up
+	@go tool river migrate-up
 
 	@echo "Running database tests (TestDB*)..."
 	@# Disable caching with -count=1, since go does not cache bust when .sql files change
-	@set -a; source docker.env; PGPORT=5433; set +a; \
-	go test ./... -run TestDB -count=1
+	@go test ./... -run TestDB -count=1
 
 .PHONY: jwt
 jwt:

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+# Use bash so we can use `source`.
+SHELL := /bin/bash
+
 .PHONY: db-up
 db-up:
 	docker compose up --detach --wait
@@ -131,7 +134,6 @@ test-db:
 .PHONY: test-db-ci
 test-db-ci:
 	@# Assume the database is up, but not migrated.
-
 	@# Equivalent to `make db-init`, but for the ephemeral database
 	@set -a; source docker.env; PGDATABASE=postgres PGPORT=5433; set +a; \
 	go tool tern migrate --config sql/init/tern.conf --migrations sql/init

--- a/ci/bin/checks.sh
+++ b/ci/bin/checks.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -exo pipefail
+
+go mod download
+
+test -z "$(gofmt -l .)"
+
+go vet ./...
+
+go build .
+
+go test -v ./... -skip TestDB

--- a/ci/bin/entrypoint.sh
+++ b/ci/bin/entrypoint.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+
+# Inspired by concourse/docker-image-resource:
+# https://github.com/concourse/docker-image-resource/blob/master/assets/common.sh
+
+set -o errexit -o pipefail -o nounset
+
+# Waits DOCKERD_TIMEOUT seconds for startup (default: 60)
+DOCKERD_TIMEOUT="${DOCKERD_TIMEOUT:-60}"
+# Accepts optional DOCKER_OPTS (default: --data-root /scratch/docker)
+DOCKER_OPTS="${DOCKER_OPTS:-}"
+
+# Constants
+DOCKERD_PID_FILE="/tmp/docker.pid"
+DOCKERD_LOG_FILE="/tmp/docker.log"
+
+sanitize_cgroups() {
+  local cgroup="/sys/fs/cgroup"
+
+  mkdir -p "${cgroup}"
+  if ! mountpoint -q "${cgroup}"; then
+    if ! mount -t tmpfs -o uid=0,gid=0,mode=0755 cgroup "${cgroup}"; then
+      echo >&2 "Could not make a tmpfs mount. Did you use --privileged?"
+      exit 1
+    fi
+  fi
+  mount -o remount,rw "${cgroup}"
+
+  # Skip AppArmor
+  # See: https://github.com/moby/moby/commit/de191e86321f7d3136ff42ff75826b8107399497
+  export container=docker
+
+  # Mount /sys/kernel/security
+  if [[ -d /sys/kernel/security ]] && ! mountpoint -q /sys/kernel/security; then
+    if ! mount -t securityfs none /sys/kernel/security; then
+      echo >&2 "Could not mount /sys/kernel/security."
+      echo >&2 "AppArmor detection and --privileged mode might break."
+    fi
+  fi
+
+  sed -e 1d /proc/cgroups | while read sys hierarchy num enabled; do
+    if [[ "${enabled}" != "1" ]]; then
+      # subsystem disabled; skip
+      continue
+    fi
+
+    grouping="$(cat /proc/self/cgroup | cut -d: -f2 | grep "\\<${sys}\\>")"
+    if [[ -z "${grouping}" ]]; then
+      # subsystem not mounted anywhere; mount it on its own
+      grouping="${sys}"
+    fi
+
+    mountpoint="${cgroup}/${grouping}"
+
+    mkdir -p "${mountpoint}"
+
+    # clear out existing mount to make sure new one is read-write
+    if mountpoint -q "${mountpoint}"; then
+      umount "${mountpoint}"
+    fi
+
+    mount -n -t cgroup -o "${grouping}" cgroup "${mountpoint}"
+
+    if [[ "${grouping}" != "${sys}" ]]; then
+      if [[ -L "${cgroup}/${sys}" ]]; then
+        rm "${cgroup}/${sys}"
+      fi
+
+      ln -s "${mountpoint}" "${cgroup}/${sys}"
+    fi
+  done
+
+  # Initialize systemd cgroup if host isn't using systemd.
+  # Workaround for https://github.com/docker/for-linux/issues/219
+  if ! [[ -d /sys/fs/cgroup/systemd ]]; then
+    mkdir "${cgroup}/systemd"
+    mount -t cgroup -o none,name=systemd cgroup "${cgroup}/systemd"
+  fi
+}
+
+# Setup container environment and start docker daemon in the background.
+start_docker() {
+  echo >&2 "Setting up Docker environment..."
+  mkdir -p /var/log
+  mkdir -p /var/run
+
+  sanitize_cgroups
+
+  # check for /proc/sys being mounted readonly, as systemd does
+  if grep '/proc/sys\s\+\w\+\s\+ro,' /proc/mounts >/dev/null; then
+    mount -o remount,rw /proc/sys
+  fi
+
+  local docker_opts="${DOCKER_OPTS:-}"
+
+  # Use Concourse's scratch volume to bypass the graph filesystem by default
+  if [[ "${docker_opts}" != *'--data-root'* ]] && [[ "${docker_opts}" != *'--graph'* ]]; then
+    docker_opts+=' --data-root /scratch/docker'
+  fi
+
+  rm -f "${DOCKERD_PID_FILE}"
+  touch "${DOCKERD_LOG_FILE}"
+
+  echo >&2 "Starting Docker..."
+  dockerd ${docker_opts} &>"${DOCKERD_LOG_FILE}" &
+  echo "$!" > "${DOCKERD_PID_FILE}"
+}
+
+# Wait for docker daemon to be healthy
+# Timeout after DOCKERD_TIMEOUT seconds
+await_docker() {
+  local timeout="${DOCKERD_TIMEOUT}"
+  echo >&2 "Waiting ${timeout} seconds for Docker to be available..."
+  local start=${SECONDS}
+  timeout=$(( timeout + start ))
+  until docker info &>/dev/null; do
+    if (( SECONDS >= timeout )); then
+      echo >&2 'Timed out trying to connect to docker daemon.'
+      if [[ -f "${DOCKERD_LOG_FILE}" ]]; then
+        echo >&2 '---DOCKERD LOGS---'
+        cat >&2 "${DOCKERD_LOG_FILE}"
+      fi
+      exit 1
+    fi
+    if [[ -f "${DOCKERD_PID_FILE}" ]] && ! kill -0 $(cat "${DOCKERD_PID_FILE}"); then
+      echo >&2 'Docker daemon failed to start.'
+      if [[ -f "${DOCKERD_LOG_FILE}" ]]; then
+        echo >&2 '---DOCKERD LOGS---'
+        cat >&2 "${DOCKERD_LOG_FILE}"
+      fi
+      exit 1
+    fi
+    sleep 1
+  done
+  local duration=$(( SECONDS - start ))
+  echo >&2 "Docker available after ${duration} seconds."
+}
+
+# Gracefully stop Docker daemon.
+stop_docker() {
+  if ! [[ -f "${DOCKERD_PID_FILE}" ]]; then
+    return 0
+  fi
+  local docker_pid="$(cat ${DOCKERD_PID_FILE})"
+  if [[ -z "${docker_pid}" ]]; then
+    return 0
+  fi
+  echo >&2 "Terminating Docker daemon."
+  kill -TERM ${docker_pid}
+  local start=${SECONDS}
+  echo >&2 "Waiting for Docker daemon to exit..."
+  wait ${docker_pid}
+  local duration=$(( SECONDS - start ))
+  echo >&2 "Docker exited after ${duration} seconds."
+}
+
+start_docker
+trap stop_docker EXIT
+await_docker
+
+# do not exec, because exec disables traps
+if [[ "$#" != "0" ]]; then
+  "$@"
+else
+  bash --login
+fi

--- a/ci/compose.yaml
+++ b/ci/compose.yaml
@@ -1,21 +1,8 @@
-# For use with local development only.
+# For use in CI.
 # From postgres Docker README: https://github.com/docker-library/docs/blob/master/postgres/README.md#-via-docker-compose
 services:
-  db:
-    image: postgres:15
-    restart: always
-    shm_size: 128mb
-    ports:
-      - 5432:5432
-    volumes:
-      - type: tmpfs
-        target: /dev/shm
-        tmpfs:
-          size: 134217728 # 128*2^20 bytes = 128Mb
-    environment:
-      POSTGRES_PASSWORD: postgres
   test-db-ephemeral:
-    image: postgres:15
+    image: postgres:ci
     restart: always
     shm_size: 128mb
     ports:
@@ -32,3 +19,19 @@ services:
       interval: 2s
       timeout: 2s
       retries: 30
+  go-test-db:
+    image: general-task:ci
+    depends_on:
+      test-db-ephemeral:
+        condition: service_healthy
+    working_dir: /app
+    volumes:
+      - .:/app
+    environment:
+      PGHOST: test-db-ephemeral
+      PGPORT: "5432" # internal to compose network
+      PGUSER: postgres
+      PGPASSWORD: postgres
+      PGDATABASE: billing
+      PGSSLMODE: disable
+    command: ["make", "test-db-ci"]

--- a/ci/compose.yaml
+++ b/ci/compose.yaml
@@ -26,7 +26,7 @@ services:
         condition: service_healthy
     working_dir: /app
     volumes:
-      - .:/app
+      - ../.:/app
     environment:
       PGHOST: test-db-ephemeral
       PGPORT: "5432" # internal to compose network

--- a/ci/partials/go-checks.yml
+++ b/ci/partials/go-checks.yml
@@ -1,0 +1,14 @@
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: general-task
+    aws_region: us-gov-west-1
+    tag: latest
+inputs:
+  - name: src
+run:
+  dir: src
+  path: ci/bin/checks.sh

--- a/ci/partials/go-test-db.yml
+++ b/ci/partials/go-test-db.yml
@@ -9,7 +9,7 @@ image_resource:
     tag: latest
 inputs:
   - name: src
-  # - name: postgres
+  - name: postgres
   # - name: general-task
 run:
   dir: src

--- a/ci/partials/go-test-db.yml
+++ b/ci/partials/go-test-db.yml
@@ -1,0 +1,28 @@
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: pages-dind-v25
+    aws_region: us-gov-west-1
+    tag: latest
+inputs:
+  - name: src
+  - name: postgres
+  - name: general-task
+run:
+  dir: /usr/local/bin
+  path: docker-entrypoint.sh
+  args:
+    - bash
+    - -ceux
+    - |
+      cd /opt/concourse-ci/task/src
+      cp docker.env.example docker.env
+
+      docker compose down --volumes test-db-ephemeral
+      docker compose up --detach --wait test-db-ephemeral
+
+      # Run the tests in the general-task image so the go toolchain and `source` are available.
+      docker run --rm "$(docker build --build-arg base_image=general-task -q .)" make test-db-ci

--- a/ci/partials/go-test-db.yml
+++ b/ci/partials/go-test-db.yml
@@ -16,7 +16,6 @@ run:
     - bash
     - -ceux
     - |
-      pwd
       cp docker.env.example docker.env
 
       docker compose down --volumes test-db-ephemeral

--- a/ci/partials/go-test-db.yml
+++ b/ci/partials/go-test-db.yml
@@ -16,10 +16,5 @@ run:
     - bash
     - -ceux
     - |
-      cp docker.env.example docker.env
-
-      docker compose down --volumes test-db-ephemeral
       docker compose up --detach --wait test-db-ephemeral
-
-      # Run the tests in the general-task image so the go toolchain and `source` are available.
-      docker run --rm "$(docker build --build-arg base_image=golang -q .)" make test-db-ci
+      docker compose run --rm go-test-db

--- a/ci/partials/go-test-db.yml
+++ b/ci/partials/go-test-db.yml
@@ -16,7 +16,7 @@ run:
     - bash
     - -ceux
     - |
-      cd /opt/concourse-ci/task/src
+      cd src
       cp docker.env.example docker.env
 
       docker compose down --volumes test-db-ephemeral

--- a/ci/partials/go-test-db.yml
+++ b/ci/partials/go-test-db.yml
@@ -12,7 +12,8 @@ inputs:
   - name: postgres
   - name: general-task
 run:
-  path: /usr/local/bin/docker-entrypoint.sh
+  dir: src
+  path: ci/bin/entrypoint.sh
   args:
     - bash
     - -ceux

--- a/ci/partials/go-test-db.yml
+++ b/ci/partials/go-test-db.yml
@@ -16,7 +16,7 @@ run:
     - bash
     - -ceux
     - |
-      cd src
+      pwd
       cp docker.env.example docker.env
 
       docker compose down --volumes test-db-ephemeral

--- a/ci/partials/go-test-db.yml
+++ b/ci/partials/go-test-db.yml
@@ -9,8 +9,8 @@ image_resource:
     tag: latest
 inputs:
   - name: src
-  - name: postgres
-  # - name: general-task
+  # - name: postgres
+  - name: general-task
 run:
   dir: src
   path: ci/bin/entrypoint.sh

--- a/ci/partials/go-test-db.yml
+++ b/ci/partials/go-test-db.yml
@@ -9,8 +9,8 @@ image_resource:
     tag: latest
 inputs:
   - name: src
-  - name: postgres
-  - name: general-task
+  # - name: postgres
+  # - name: general-task
 run:
   dir: src
   path: ci/bin/entrypoint.sh

--- a/ci/partials/go-test-db.yml
+++ b/ci/partials/go-test-db.yml
@@ -9,6 +9,8 @@ image_resource:
     tag: latest
 inputs:
   - name: src
+  - name: general-task
+  - name: postgres
 run:
   dir: src
   path: ci/bin/entrypoint.sh
@@ -16,5 +18,12 @@ run:
     - bash
     - -ceux
     - |
-      docker compose up --detach --wait test-db-ephemeral
-      docker compose run --rm go-test-db
+      pushd ..
+        docker load -i general-task/image.tar
+        docker tag "$(cat general-task/repository):$(cat general-task/tag)" general-task:ci
+        docker load -i postgres/image.tar
+        docker tag "$(cat postgres/repository):$(cat postgres/tag)" postgres:ci
+      popd
+      docker network prune -f
+      docker compose -f ci/compose.yaml up --detach --wait test-db-ephemeral
+      docker compose -f ci/compose.yaml run --rm go-test-db

--- a/ci/partials/go-test-db.yml
+++ b/ci/partials/go-test-db.yml
@@ -9,8 +9,6 @@ image_resource:
     tag: latest
 inputs:
   - name: src
-  # - name: postgres
-  - name: general-task
 run:
   dir: src
   path: ci/bin/entrypoint.sh
@@ -18,7 +16,6 @@ run:
     - bash
     - -ceux
     - |
-      exit 1
       cd /opt/concourse-ci/task/src
       cp docker.env.example docker.env
 

--- a/ci/partials/go-test-db.yml
+++ b/ci/partials/go-test-db.yml
@@ -12,8 +12,7 @@ inputs:
   - name: postgres
   - name: general-task
 run:
-  dir: /usr/local/bin
-  path: docker-entrypoint.sh
+  path: /usr/local/bin/docker-entrypoint.sh
   args:
     - bash
     - -ceux

--- a/ci/partials/go-test-db.yml
+++ b/ci/partials/go-test-db.yml
@@ -23,4 +23,4 @@ run:
       docker compose up --detach --wait test-db-ephemeral
 
       # Run the tests in the general-task image so the go toolchain and `source` are available.
-      docker run --rm "$(docker build --build-arg base_image=general-task -q .)" make test-db-ci
+      docker run --rm "$(docker build --build-arg base_image=golang -q .)" make test-db-ci

--- a/ci/partials/go-test-db.yml
+++ b/ci/partials/go-test-db.yml
@@ -18,6 +18,7 @@ run:
     - bash
     - -ceux
     - |
+      exit 1
       cd /opt/concourse-ci/task/src
       cp docker.env.example docker.env
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -13,7 +13,11 @@ jobs:
             version: every
             trigger: true
           - get: postgres
+            params:
+              format: oci
           - get: general-task
+            params:
+              format: oci
       - put: pull-request
         params:
           path: pull-request

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -19,12 +19,12 @@ jobs:
           path: pull-request
           status: pending
       - task: go-checks
-        file: ci/partials/go-checks.yml
+        file: pull-request/ci/partials/go-checks.yml
         input_mapping:
           src: pull-request
       - task: go-test-db
         privileged: true
-        file: ci/partials/go-test-db.yml
+        file: pull-request/ci/partials/go-test-db.yml
 
     on_failure:
       put: pull-request

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -254,7 +254,7 @@ resources:
     source:
       commit_verification_keys: ((cloud-gov-pgp-keys))
       uri: https://github.com/cloud-gov/billing.git
-      branch: pr-workflow
+      branch: main
       paths:
         - ci/terraform/*
 
@@ -272,7 +272,7 @@ resources:
     source:
       commit_verification_keys: ((cloud-gov-pgp-keys))
       uri: https://github.com/cloud-gov/billing.git
-      branch: pr-workflow
+      branch: main
       paths:
         - ci/*
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -23,7 +23,7 @@ jobs:
         input_mapping:
           src: pull-request
       - task: go-test-db
-        privileged: true
+        privileged: true # Required for docker-in-docker.
         file: pull-request/ci/partials/go-test-db.yml
         input_mapping:
           src: pull-request

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -14,14 +14,14 @@ jobs:
             trigger: true
           - get: postgres
           - get: general-task
-      # - put: pull-request
-      #   params:
-      #     path: pull-request
-      #     status: pending
-      # - task: go-checks
-      #   file: pull-request/ci/partials/go-checks.yml
-      #   input_mapping:
-      #     src: pull-request
+      - put: pull-request
+        params:
+          path: pull-request
+          status: pending
+      - task: go-checks
+        file: pull-request/ci/partials/go-checks.yml
+        input_mapping:
+          src: pull-request
       - task: go-test-db
         privileged: true
         file: pull-request/ci/partials/go-test-db.yml

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -298,7 +298,6 @@ resources:
       repository: cloud-gov/billing
       access_token: ((cg-ci-bot-ghtoken))
       disable_forks: true
-      base_branch: main
 
   - name: postgres
     type: registry-image

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -298,7 +298,7 @@ resources:
     source:
       aws_access_key_id: ((ecr_aws_key))
       aws_secret_access_key: ((ecr_aws_secret))
-      repository: pages-postgres-15
+      repository: pages-postgres-v15
       aws_region: us-gov-west-1
       tag: latest
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -298,6 +298,7 @@ resources:
       repository: cloud-gov/billing
       access_token: ((cg-ci-bot-ghtoken))
       disable_forks: true
+      base_branch: main
 
   - name: postgres
     type: registry-image

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -252,7 +252,7 @@ resources:
     source:
       commit_verification_keys: ((cloud-gov-pgp-keys))
       uri: https://github.com/cloud-gov/billing.git
-      branch: main
+      branch: pr-workflow
       paths:
         - ci/terraform/*
 
@@ -270,7 +270,7 @@ resources:
     source:
       commit_verification_keys: ((cloud-gov-pgp-keys))
       uri: https://github.com/cloud-gov/billing.git
-      branch: main
+      branch: pr-workflow
       paths:
         - ci/*
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -19,12 +19,12 @@ jobs:
           path: pull-request
           status: pending
       - task: go-checks
-        file: pull-request/ci/partials/go-checks.yml
+        file: src/ci/partials/go-checks.yml
         input_mapping:
           src: pull-request
       - task: go-test-db
         privileged: true
-        file: pull-request/ci/partials/go-test-db.yml
+        file: src/ci/partials/go-test-db.yml
 
     on_failure:
       put: pull-request

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -19,12 +19,12 @@ jobs:
           path: pull-request
           status: pending
       - task: go-checks
-        file: src/ci/partials/go-checks.yml
+        file: pull-request/ci/partials/go-checks.yml
         input_mapping:
           src: pull-request
       - task: go-test-db
         privileged: true
-        file: src/ci/partials/go-test-db.yml
+        file: pull-request/ci/partials/go-test-db.yml
 
     on_failure:
       put: pull-request

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -14,14 +14,14 @@ jobs:
             trigger: true
           - get: postgres
           - get: general-task
-      - put: pull-request
-        params:
-          path: pull-request
-          status: pending
-      - task: go-checks
-        file: pull-request/ci/partials/go-checks.yml
-        input_mapping:
-          src: pull-request
+      # - put: pull-request
+      #   params:
+      #     path: pull-request
+      #     status: pending
+      # - task: go-checks
+      #   file: pull-request/ci/partials/go-checks.yml
+      #   input_mapping:
+      #     src: pull-request
       - task: go-test-db
         privileged: true
         file: pull-request/ci/partials/go-test-db.yml

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -25,6 +25,8 @@ jobs:
       - task: go-test-db
         privileged: true
         file: pull-request/ci/partials/go-test-db.yml
+        input_mapping:
+          src: pull-request
 
     on_failure:
       put: pull-request

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -6,6 +6,37 @@ jobs:
       - set_pipeline: self
         file: src/ci/pipeline.yml
 
+  - name: pull-request
+    plan:
+      - in_parallel:
+          - get: pull-request
+            version: every
+            trigger: true
+          - get: postgres
+          - get: general-task
+      - put: pull-request
+        params:
+          path: pull-request
+          status: pending
+      - task: go-checks
+        file: ci/partials/go-checks.yml
+        input_mapping:
+          src: pull-request
+      - task: go-test-db
+        privileged: true
+        file: ci/partials/go-test-db.yml
+
+    on_failure:
+      put: pull-request
+      params:
+        path: pull-request
+        status: failure
+    on_success:
+      put: pull-request
+      params:
+        path: pull-request
+        status: success
+
   - name: terraform-plan-billing-development
     plan:
       - in_parallel:
@@ -254,6 +285,23 @@ resources:
       # Terraform requires the cache directory to exist, even if empty.
       initial_content_binary: H4sIAHqo3GcAAyvIKU3PzNNNTkzOSNVnoA0wMDAwNzVVANNmENrAyARCQ4GCoYm5mbmhkYmhibGCgaGpqYkJg4IpjdyDAkqLSxKLgE7JSsxNLS7JyE/OSExJzcFUB1SWlobHHKg/4PQoGAWjYBQMcgAA4m+yIwAGAAA=
 
+  - name: pull-request
+    type: pull-request
+    check_every: 1m
+    source:
+      repository: cloud-gov/billing
+      access_token: ((cg-ci-bot-ghtoken))
+      disable_forks: true
+
+  - name: postgres
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: pages-postgres-15
+      aws_region: us-gov-west-1
+      tag: latest
+
 resource_types:
   - name: registry-image
     type: registry-image
@@ -279,5 +327,14 @@ resource_types:
       aws_access_key_id: ((ecr_aws_key))
       aws_secret_access_key: ((ecr_aws_secret))
       repository: s3-resource
+      aws_region: us-gov-west-1
+      tag: latest
+
+  - name: pull-request
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: github-pr-resource
       aws_region: us-gov-west-1
       tag: latest

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -254,7 +254,7 @@ resources:
     source:
       commit_verification_keys: ((cloud-gov-pgp-keys))
       uri: https://github.com/cloud-gov/billing.git
-      branch: main
+      branch: pr-workflow
       paths:
         - ci/terraform/*
 
@@ -272,7 +272,7 @@ resources:
     source:
       commit_verification_keys: ((cloud-gov-pgp-keys))
       uri: https://github.com/cloud-gov/billing.git
-      branch: main
+      branch: pr-workflow
       paths:
         - ci/*
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -258,7 +258,7 @@ resources:
     source:
       commit_verification_keys: ((cloud-gov-pgp-keys))
       uri: https://github.com/cloud-gov/billing.git
-      branch: pr-workflow
+      branch: main
       paths:
         - ci/terraform/*
 
@@ -276,7 +276,7 @@ resources:
     source:
       commit_verification_keys: ((cloud-gov-pgp-keys))
       uri: https://github.com/cloud-gov/billing.git
-      branch: pr-workflow
+      branch: main
       paths:
         - ci/*
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -46,4 +46,5 @@ services:
       PGUSER: postgres
       PGPASSWORD: postgres
       PGDATABASE: billing
+      PGSSLMODE: disable
     command: ["make", "test-db-ci"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -42,8 +42,8 @@ services:
       - .:/app
     environment:
       PGHOST: test-db-ephemeral
-      PGPORT: "5433"
+      PGPORT: "5432" # internal to compose network
       PGUSER: postgres
       PGPASSWORD: postgres
       PGDATABASE: billing
-    command: ["bash", "-lc", "make test-db-ci"]
+    command: ["make", "test-db-ci"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -27,6 +27,11 @@ services:
           size: 134217728 # 128*2^20 bytes = 128Mb
     environment:
       POSTGRES_PASSWORD: postgres
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d postgres"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
   go-test-db:
     image: golang
     depends_on:

--- a/compose.yaml
+++ b/compose.yaml
@@ -27,3 +27,18 @@ services:
           size: 134217728 # 128*2^20 bytes = 128Mb
     environment:
       POSTGRES_PASSWORD: postgres
+  go-test-db:
+    image: golang
+    depends_on:
+      test-db-ephemeral:
+        condition: service_healthy
+    working_dir: /app
+    volumes:
+      - .:/app
+    environment:
+      PGHOST: test-db-ephemeral
+      PGPORT: "5433"
+      PGUSER: postgres
+      PGPASSWORD: postgres
+      PGDATABASE: billing
+    command: ["bash", "-lc", "make test-db-ci"]


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add a pull request CI job that runs static checks on the Go code, unit tests, and database tests.
- Database tests require Docker Compose to orchestrate without outside infrastructure.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None.