### PR TITLE
Stop filtering src to only watch ci/ folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ The application uses service account credentials to authenticate to the Cloud Fo
 
 Note that table name `schema_version` is reserved by tern for tracking migration status.
 
+Connect to the database in a CF environment with [cf-service-connect](https://github.com/cloud-gov/cf-service-connect):
+
+```
+cf connect-to-service billing billing-db
+```
+
 ### Dependencies
 
 Why does this project use the packages that it does?

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -240,8 +240,6 @@ resources:
       commit_verification_keys: ((cloud-gov-pgp-keys))
       uri: https://github.com/cloud-gov/billing.git
       branch: main
-      paths:
-        - ci/*
 
   - name: terraform-plugin-cache
     type: s3-iam


### PR DESCRIPTION
## Changes proposed in this pull request:

- We want all changes to src to trigger a rebuild. Also document how to connect to live database. 

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None.