### PR TITLE
Conform to pipeline-tasks tf-apply required input name

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -48,14 +48,15 @@ jobs:
       - in_parallel:
           - get: terraform-plugin-cache
             trigger: false
-          - get: src
+          - get: terraform-templates
+            resource: src
             trigger: true
             passed: [set-self]
           - get: pipeline-tasks
           - get: general-task
       - task: terraform-plan
         image: general-task
-        file: src/ci/terraform/terraform-apply.yml
+        file: terraform-templates/ci/terraform/terraform-apply.yml
         params: &tf-billing-development
           TERRAFORM_ACTION: plan
           TEMPLATE_SUBDIR: ci/terraform/stack
@@ -74,7 +75,7 @@ jobs:
             CF_CLIENT_SECRET: ((billing-cf-client-secret-development))
             OIDC_ISSUER: ((oidc-issuer-development))
           TF_VAR_org_name: ((org-name))
-          TF_VAR_path: ../../.. # src, relative to TEMPLATE_SUBDIR, where terraform executes
+          TF_VAR_path: ../../.. # terraform-templates, relative to TEMPLATE_SUBDIR, where terraform executes
           TF_VAR_space_name: ((space-name))
       - put: terraform-plugin-cache
         params:
@@ -85,21 +86,22 @@ jobs:
       - in_parallel:
           - get: terraform-plugin-cache
             trigger: false
-          - get: src
+          - get: terraform-templates
+            resource: src
             trigger: true
             passed: [terraform-plan-billing-development]
           - get: pipeline-tasks
           - get: general-task
       - task: terraform-apply
         image: general-task
-        file: src/ci/terraform/terraform-apply.yml
+        file: terraform-templates/ci/terraform/terraform-apply.yml
         params:
           <<: *tf-billing-development
           TF_UPDATE_PLUGIN_CACHE: false
           TERRAFORM_ACTION: apply
       - task: terraform-cleanup
         image: general-task
-        file: src/ci/terraform/terraform-cleanup.yml
+        file: terraform-templates/ci/terraform/terraform-cleanup.yml
         params:
           CF_API_URL: ((dev-cf-api-url))
           CF_CLIENT_ID: ((deploy-billing-cf-client-id))
@@ -110,14 +112,15 @@ jobs:
       - in_parallel:
           - get: terraform-plugin-cache
             trigger: false
-          - get: src
+          - get: terraform-templates
+            resource: src
             trigger: true
             passed: [terraform-apply-billing-development]
           - get: pipeline-tasks
           - get: general-task
       - task: terraform-plan
         image: general-task
-        file: src/ci/terraform/terraform-apply.yml
+        file: terraform-templates/ci/terraform/terraform-apply.yml
         params: &tf-billing-staging
           TERRAFORM_ACTION: plan
           TEMPLATE_SUBDIR: ci/terraform/stack
@@ -136,7 +139,7 @@ jobs:
             CF_CLIENT_SECRET: ((billing-cf-client-secret-staging))
             OIDC_ISSUER: ((oidc-issuer-staging))
           TF_VAR_org_name: ((org-name))
-          TF_VAR_path: ../../.. # src, relative to TEMPLATE_SUBDIR, where terraform executes
+          TF_VAR_path: ../../.. # terraform-templates, relative to TEMPLATE_SUBDIR, where terraform executes
           TF_VAR_space_name: ((space-name))
 
   - name: terraform-apply-billing-staging
@@ -144,20 +147,21 @@ jobs:
       - in_parallel:
           - get: terraform-plugin-cache
             trigger: false
-          - get: src
+          - get: terraform-templates
+            resource: src
             trigger: true
             passed: [terraform-plan-billing-staging]
           - get: pipeline-tasks
           - get: general-task
       - task: terraform-apply
         image: general-task
-        file: src/ci/terraform/terraform-apply.yml
+        file: terraform-templates/ci/terraform/terraform-apply.yml
         params:
           <<: *tf-billing-staging
           TERRAFORM_ACTION: apply
       - task: terraform-cleanup
         image: general-task
-        file: src/ci/terraform/terraform-cleanup.yml
+        file: terraform-templates/ci/terraform/terraform-cleanup.yml
         params:
           CF_API_URL: ((staging-cf-api-url))
           CF_CLIENT_ID: ((deploy-billing-cf-client-id))
@@ -168,14 +172,15 @@ jobs:
       - in_parallel:
           - get: terraform-plugin-cache
             trigger: false
-          - get: src
+          - get: terraform-templates
+            resource: src
             trigger: true
             passed: [terraform-apply-billing-staging]
           - get: pipeline-tasks
           - get: general-task
       - task: terraform-plan
         image: general-task
-        file: src/ci/terraform/terraform-apply.yml
+        file: terraform-templates/ci/terraform/terraform-apply.yml
         params: &tf-billing-production
           TERRAFORM_ACTION: plan
           TEMPLATE_SUBDIR: ci/terraform/stack
@@ -194,7 +199,7 @@ jobs:
             CF_CLIENT_SECRET: ((billing-cf-client-secret-production))
             OIDC_ISSUER: ((oidc-issuer-production))
           TF_VAR_org_name: ((org-name))
-          TF_VAR_path: ../../.. # src, relative to TEMPLATE_SUBDIR, where terraform executes
+          TF_VAR_path: ../../.. # terraform-templates, relative to TEMPLATE_SUBDIR, where terraform executes
           TF_VAR_space_name: ((space-name))
 
   - name: terraform-apply-billing-production
@@ -202,20 +207,21 @@ jobs:
       - in_parallel:
           - get: terraform-plugin-cache
             trigger: false
-          - get: src
+          - get: terraform-templates
+            resource: src
             trigger: true
             passed: [terraform-plan-billing-production]
           - get: pipeline-tasks
           - get: general-task
       - task: terraform-apply
         image: general-task
-        file: src/ci/terraform/terraform-apply.yml
+        file: terraform-templates/ci/terraform/terraform-apply.yml
         params:
           <<: *tf-billing-production
           TERRAFORM_ACTION: apply
       - task: terraform-cleanup
         image: general-task
-        file: src/ci/terraform/terraform-cleanup.yml
+        file: terraform-templates/ci/terraform/terraform-cleanup.yml
         params:
           CF_API_URL: ((prod-cf-api-url))
           CF_CLIENT_ID: ((deploy-billing-cf-client-id))


### PR DESCRIPTION
## Changes proposed in this pull request:

In a2fb635, I forgot that our own `terraform-apply` step calls a step by the same name in `pipeline-tasks`, and that step requires an input named `terraform-templates`. This change renames `src` to match, but keeps the same underlying resource, so the fix from a2fb635 still applies.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None.