### PR TITLE
Fix missed references to src in step inputs

### DIFF
--- a/ci/terraform/terraform-apply.yml
+++ b/ci/terraform/terraform-apply.yml
@@ -4,10 +4,10 @@ platform: linux
 inputs:
   - name: pipeline-tasks
   - name: terraform-plugin-cache
-  - name: src
+  - name: terraform-templates
 outputs:
   - name: terraform-state
   - name: updated-terraform-plugin-cache
 
 run:
-  path: src/ci/terraform/terraform-apply.sh
+  path: terraform-templates/ci/terraform/terraform-apply.sh

--- a/ci/terraform/terraform-cleanup.yml
+++ b/ci/terraform/terraform-cleanup.yml
@@ -2,8 +2,8 @@
 platform: linux
 
 inputs:
-  - name: src
+  - name: terraform-templates
   - name: terraform-state
 
 run:
-  path: src/ci/terraform/terraform-cleanup.sh
+  path: terraform-templates/ci/terraform/terraform-cleanup.sh


### PR DESCRIPTION
## Changes proposed in this pull request:

- Forgot to rename these as part of the previous PR.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None.