### PR TITLE
Go 1.25 is not yet supported by the Go buildpack; drop back to 1.24

### DIFF
--- a/ci/terraform/stack/billing.tf
+++ b/ci/terraform/stack/billing.tf
@@ -33,7 +33,7 @@ resource "cloudfoundry_app" "billing" {
 
   environment = merge(
     {
-      "GOVERSION" = "1.25"
+      "GOVERSION" = "1.24"
     },
     var.environment
   )


### PR DESCRIPTION
## Changes proposed in this pull request:

- Reverts part of a2fb6357d1b304c82e353733f24b0b2b49904a2a

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None.