### PR TITLE
Print build version (git short ref) on program start

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -54,6 +54,8 @@ jobs:
             passed: [set-self]
           - get: pipeline-tasks
           - get: general-task
+      - load_var: short-ref
+        file: terraform-templates/.git/short_ref
       - task: terraform-plan
         image: general-task
         file: terraform-templates/ci/terraform/terraform-apply.yml
@@ -76,6 +78,7 @@ jobs:
             OIDC_ISSUER: ((oidc-issuer-development))
           TF_VAR_org_name: ((org-name))
           TF_VAR_path: ../../.. # terraform-templates, relative to TEMPLATE_SUBDIR, where terraform executes
+          TF_VAR_short_ref: ((.:short-ref))
           TF_VAR_space_name: ((space-name))
       - put: terraform-plugin-cache
         params:
@@ -118,6 +121,8 @@ jobs:
             passed: [terraform-apply-billing-development]
           - get: pipeline-tasks
           - get: general-task
+      - load_var: short-ref
+        file: terraform-templates/.git/short_ref
       - task: terraform-plan
         image: general-task
         file: terraform-templates/ci/terraform/terraform-apply.yml
@@ -140,6 +145,7 @@ jobs:
             OIDC_ISSUER: ((oidc-issuer-staging))
           TF_VAR_org_name: ((org-name))
           TF_VAR_path: ../../.. # terraform-templates, relative to TEMPLATE_SUBDIR, where terraform executes
+          TF_VAR_short_ref: ((.:short-ref))
           TF_VAR_space_name: ((space-name))
 
   - name: terraform-apply-billing-staging
@@ -178,6 +184,8 @@ jobs:
             passed: [terraform-apply-billing-staging]
           - get: pipeline-tasks
           - get: general-task
+      - load_var: short-ref
+        file: terraform-templates/.git/short_ref
       - task: terraform-plan
         image: general-task
         file: terraform-templates/ci/terraform/terraform-apply.yml
@@ -200,6 +208,7 @@ jobs:
             OIDC_ISSUER: ((oidc-issuer-production))
           TF_VAR_org_name: ((org-name))
           TF_VAR_path: ../../.. # terraform-templates, relative to TEMPLATE_SUBDIR, where terraform executes
+          TF_VAR_short_ref: ((.:short-ref))
           TF_VAR_space_name: ((space-name))
 
   - name: terraform-apply-billing-production

--- a/ci/terraform/stack/billing.tf
+++ b/ci/terraform/stack/billing.tf
@@ -33,7 +33,9 @@ resource "cloudfoundry_app" "billing" {
 
   environment = merge(
     {
-      "GOVERSION" = "1.24"
+      "GO_LINKER_SYMBOL" = "main.BuildVersion"
+      "GO_LINKER_VALUE"  = var.short_ref
+      "GOVERSION"        = "1.24"
     },
     var.environment
   )

--- a/ci/terraform/stack/variables.tf
+++ b/ci/terraform/stack/variables.tf
@@ -35,3 +35,8 @@ variable "environment" {
   })
   sensitive = true
 }
+
+variable "short_ref" {
+  type        = string
+  description = "The git short ref of the current commit. E.g. a1b2c3d."
+}

--- a/main.go
+++ b/main.go
@@ -31,6 +31,11 @@ import (
 )
 
 var (
+	// BuildVersion is a commit SHA or branch ref. It is set during linking if provided and logged when the application starts.
+	BuildVersion string = "devel"
+)
+
+var (
 	ErrBadConfig        = errors.New("reading config from environment")
 	ErrCFClient         = errors.New("creating Cloud Foundry client")
 	ErrCFConfig         = errors.New("parsing Cloud Foundry connection configuration")
@@ -63,6 +68,7 @@ func run(ctx context.Context, out io.Writer) error {
 	logger := slog.New(slog.NewJSONHandler(out, &slog.HandlerOptions{
 		Level: c.LogLevel,
 	}))
+	logger.Info("build version: " + BuildVersion)
 	logger.Debug("run: initializing CF client")
 	cfconf, err := cfconfig.New(c.CFApiUrl,
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Provide the ref to the app at build time using the buildpack's linker symbol feature. See https://docs.cloudfoundry.org/buildpacks/go/index.html#passing_symbol_linker
- SHA is available in `.git/short_ref` thanks to the git resource: https://github.com/concourse/git-resource?tab=readme-ov-file#additional-files-populated

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None.