### PR TITLE
Add missing load_var to apply steps

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -95,6 +95,8 @@ jobs:
             passed: [terraform-plan-billing-development]
           - get: pipeline-tasks
           - get: general-task
+      - load_var: short-ref
+        file: terraform-templates/.git/short_ref
       - task: terraform-apply
         image: general-task
         file: terraform-templates/ci/terraform/terraform-apply.yml
@@ -159,6 +161,8 @@ jobs:
             passed: [terraform-plan-billing-staging]
           - get: pipeline-tasks
           - get: general-task
+      - load_var: short-ref
+        file: terraform-templates/.git/short_ref
       - task: terraform-apply
         image: general-task
         file: terraform-templates/ci/terraform/terraform-apply.yml
@@ -222,6 +226,8 @@ jobs:
             passed: [terraform-plan-billing-production]
           - get: pipeline-tasks
           - get: general-task
+      - load_var: short-ref
+        file: terraform-templates/.git/short_ref
       - task: terraform-apply
         image: general-task
         file: terraform-templates/ci/terraform/terraform-apply.yml


### PR DESCRIPTION
## Changes proposed in this pull request:

- Follow-up to 11dd3efaa71fa1326fa3768a97877e720dcea622. Even though the params are copied from plan to apply with yaml anchors, the value of the loaded var is filled in after the anchor is applied. Upshot: The apply jobs need the `load_var` step too.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None.