### PR TITLE
Reduce Go version in go.mod, since Go buildpack is stuck at 1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloud-gov/billing
 
-go 1.25
+go 1.24
 
 require (
 	github.com/cloudfoundry/go-cfclient/v3 v3.0.0-alpha.12.0.20250605163211-41fbb9ee824a


### PR DESCRIPTION
## Changes proposed in this pull request:

- The version in the Go mod determines which Go toolchain is used to build the project, and which will be used for static analysis.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Go supports [one major version behind the latest major](https://go.dev/doc/devel/release#policy), so 1.24 will still be supported and receive security updates until 1.26 is released. 