### PR TITLE
Makefile environment variable simplification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
 # Use bash so we can use `source`.
 SHELL := /bin/bash
 
-# Souce docker.env, export all valid keys
-include docker.env
-export $(shell sed -n 's/^\([A-Za-z_][A-Za-z0-9_]*\)=.*/\1/p' docker.env)
+# Source docker.env if it exists and export all valid keys
+ifneq ("$(wildcard docker.env)", "")
+	include docker.env
+	export $(shell sed -n 's/^\([A-Za-z_][A-Za-z0-9_]*\)=.*/\1/p' docker.env)
+endif
 
 .PHONY: db-up
 db-up:


### PR DESCRIPTION
## Changes proposed in this pull request:

- Exports docker.env environment variables for entire Makefile
- Removes `set -a`, relies on targeted environment settings instead

## Security considerations

Changes how environment variables are used. This includes sourced credentials to local DB and possible Cloud Foundry credential, however, these variables should not leave the environment used for the make task, and were being exported by these tasks before.

Thanks to @jameshochadel for the idea!