### PR TITLE
Makefile try to install missing deps for `entr`, `uaac`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,17 @@ debug-test-db:
 	@set -a; source docker.env; PGPORT=5433; set +a; \
 	dlv test ./internal/dbx -- -test.run TestDBPostUsage
 
+.PHONY: watch-setup
+watch-setup:
+	@if [ -z $(shell which entr) ]; then \
+	  echo -en "\033[0;33m"; \
+		echo "entr not found, attempting to install via \`brew install entr\`..."; \
+		brew install entr; \
+		echo -e "\033[0m"; \
+  fi;
+
 .PHONY: watchgen
-watchgen:
+watchgen: watch-setup
 	@echo "Watching for .sql file changes. Press ctrl+c *twice* to exit, or once to rebuild."
 	@while true; do \
 		find . -type f -name '*.sql' | entr -d make gen ; \
@@ -63,7 +72,7 @@ watchgen:
 # Run entr in a while loop because it exits when files are deleted.
 # Run targets db-up and db-init before running.
 .PHONY: watch
-watch:
+watch: watch-setup
 	@echo "Watching for .go file changes. Press ctrl+c *twice* to exit, or once to rebuild."
 	@while true; do \
 		set -a; source docker.env; set +a; \
@@ -73,7 +82,7 @@ watch:
 	done
 
 .PHONY: watchtest
-watchtest:
+watchtest: watch-setup
 	@echo "Running unit tests every time .go files change. Press ctrl+c *twice* to exit, or once to rebuild."
 	@while true; do \
 		sleep 0.5 ; \
@@ -175,7 +184,12 @@ test-db-ci:
 
 .PHONY: jwt
 jwt:
-	@set -a; source docker.env; set +a; \
+	@if [ -z $(shell which uaac) ]; then \
+	  echo -en "\033[0;33m"; \
+		echo "cf-uaac not found, attempting to install via \`gem install cf-uaac\`..."; \
+		gem install cf-uaac; \
+		echo -e "\033[0m"; \
+  fi
 	uaac target $${OIDC_ISSUER%/oauth/token}; \
 	uaac token client get $$CF_CLIENT_ID -s $$CF_CLIENT_SECRET --scope "usage.admin"; \
 	uaac context billing | grep access_token | awk '{print $$2}' > jwt.txt

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ make psql-testdb # Connect to the test database.
 Make request to the locally running server:
 
 ```sh
+# Requires `cf-uaac` and will attempt to install if missing.
 make jwt # Get a token from the configured UAA, based on OIDC_ISSUER host. Requires CF_CLIENT_ID and CF_CLIENT_SECRET to be set.
 curl -H "Authorization: bearer $(cat jwt.txt)" localhost:8080/some/path # Make a request with the authentication header set.
 ```


### PR DESCRIPTION
## Changes proposed in this pull request:

- Checks for `cf-uaac` and installs if unavailable when running `make jwt`
- Checks for `entr` and installs if unavailable when running `make watch*` targets

## Security considerations

Automatically installs two required dependencies, `cf-uaac`, and `entr`.
