### PR TITLE
Usage command: JSON reporting, measurement resilience, org names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -226,3 +226,7 @@ $tf/
 # Custom
 *.zip
 jwt.txt
+
+# CLI
+cmd/usage/usage
+cmd/usage/*.json

--- a/cmd/usage/README.md
+++ b/cmd/usage/README.md
@@ -20,14 +20,17 @@ To produce a JSON report of usage:
 1. Create a `.env` with the database connection information and other necessary variables
 
     ```env
-    export CF_API_URL=
-    export CF_CLIENT_ID=
-    export CF_CLIENT_SECRET=
+    # fill with your tunnel's connection parameters
     export PGHOST=localhost
     export PGPORT=
     export PGDATABASE=
     export PGUSER=
     export PGPASSWORD=
+    
+    # blank values are fine
+    export CF_API_URL=
+    export CF_CLIENT_ID=
+    export CF_CLIENT_SECRET=
     export OIDC_ISSUER=
     ```
 

--- a/cmd/usage/README.md
+++ b/cmd/usage/README.md
@@ -43,5 +43,5 @@ To produce a JSON report of usage:
 1. Run the usage CLI and stream output to a JSON file:
 
     ```shell
-    ./usage | jq | tee report.json
+    ./usage -cname 'some customer' | jq | tee report.json
     ```

--- a/cmd/usage/README.md
+++ b/cmd/usage/README.md
@@ -1,0 +1,44 @@
+# Billing and Usage CLI
+
+## Building the CLI
+
+```shell
+go build
+```
+
+## Using the CLI
+
+To see the CLI options:
+
+```shell
+./usage -h
+```
+
+To produce a JSON report of usage:
+
+1. Create an SSH tunnel to the billing database
+1. Create a `.env` with the database connection information and other necessary variables
+
+    ```env
+    export CF_API_URL=
+    export CF_CLIENT_ID=
+    export CF_CLIENT_SECRET=
+    export PGHOST=localhost
+    export PGPORT=
+    export PGDATABASE=
+    export PGUSER=
+    export PGPASSWORD=
+    export OIDC_ISSUER=
+    ```
+
+1. Set the environment variables in your shell:
+
+    ```shell
+    source .env
+    ```
+
+1. Run the usage CLI and stream output to a JSON file:
+
+    ```shell
+    ./usage | jq | tee report.json
+    ```

--- a/cmd/usage/main.go
+++ b/cmd/usage/main.go
@@ -114,9 +114,10 @@ func run(ctx context.Context, out io.Writer) error {
 	logger.Debug("run: got usage", "usage", nodes)
 
 	logger.Debug("run: making report")
-	slices.Reverse(nodes)
 	report := NewReporter()
 	var link ReportLinker
+
+	slices.Reverse(nodes)
 	for i, n := range nodes {
 		uCreds, err := n.TotalMicrocredits.Int64Value()
 		if err != nil {
@@ -131,10 +132,20 @@ func run(ctx context.Context, out io.Writer) error {
 
 		p := nodes[i-1]
 
+		paths := []string{}
+		levels := []pgtype.Text{n.L1, n.L2, n.L3, n.L4}
+		for _, l := range levels {
+			if !l.Valid {
+				break
+			}
+			paths = append(paths, l.String)
+		}
+		path := strings.Join(paths, ".")
+
 		// org
 		if n.L1.Valid && !n.L2.Valid {
 			// org is always linked to root
-			link, err = report.SetNode(report, uCredsInt, Org, n.L1.String, "")
+			link, err = report.SetNode(report, uCredsInt, Org, n.L1.String, path)
 			if err != nil {
 				return fmtErr(ErrCreatingReport, err)
 			}
@@ -150,7 +161,7 @@ func run(ctx context.Context, out io.Writer) error {
 			} else if p.L2.Valid { // go space/g > org
 				link = link.getParent()
 			}
-			link, err = report.SetNode(link, uCredsInt, Space, n.L2.String, "")
+			link, err = report.SetNode(link, uCredsInt, Space, n.L2.String, path)
 			if err != nil {
 				return fmtErr(ErrCreatingReport, err)
 			}
@@ -164,7 +175,7 @@ func run(ctx context.Context, out io.Writer) error {
 			} else if p.L3.Valid { // go space/s > space/g
 				link = link.getParent()
 			}
-			link, err = report.SetNode(link, uCredsInt, Space, n.L3.String, "")
+			link, err = report.SetNode(link, uCredsInt, Space, n.L3.String, path)
 			if err != nil {
 				return fmtErr(ErrCreatingReport, err)
 			}
@@ -183,7 +194,7 @@ func run(ctx context.Context, out io.Writer) error {
 				k = CfSvc
 			}
 
-			link, err = report.SetNode(link, uCredsInt, k, n.L4.String, "")
+			link, err = report.SetNode(link, uCredsInt, k, n.L4.String, path)
 			if err != nil {
 				return fmtErr(ErrCreatingReport, err)
 			}

--- a/cmd/usage/main.go
+++ b/cmd/usage/main.go
@@ -182,19 +182,22 @@ func run(ctx context.Context, out io.Writer) error {
 			continue
 		}
 
+		// TODO: we don't currently have the individual meters attached here
+		// - There aren't currently more than one meter per resource anyway
+		// - See cloud-gov/cg-interface/cg-billing#89
 		if n.L4.Valid {
 			if p.L4.Valid { // go from leaf > space/s
 				link = link.getParent()
 			}
 
-			var k Kind
+			var kind Kind
 			if isApp(n.L4) {
-				k = CfApp
+				kind = CfApp
 			} else if isService(n.L4) {
-				k = CfSvc
+				kind = CfSvc
 			}
 
-			link, err = report.SetNode(link, uCredsInt, k, n.L4.String, path)
+			link, err = report.SetNode(link, uCredsInt, kind, n.L4.String, path)
 			if err != nil {
 				return fmtErr(ErrCreatingReport, err)
 			}

--- a/cmd/usage/main.go
+++ b/cmd/usage/main.go
@@ -253,7 +253,7 @@ func buildQuery() string {
 func getCustomerID(ctx context.Context, q dbx.Querier) (id pgtype.UUID, err error) {
 	r := getRawCID()
 	if r != "" {
-		return dbx.UtilUUID(r), nil
+		return dbx.ToUUID(r), nil
 	}
 
 	cs, e := q.GetCustomersByName(ctx, cname)

--- a/cmd/usage/main.go
+++ b/cmd/usage/main.go
@@ -202,7 +202,6 @@ func run(ctx context.Context, out io.Writer) error {
 		}
 
 		logger.Debug("weirds gotten in report", "node", n)
-
 	}
 	logger.Debug("run: got report", "report", report)
 

--- a/cmd/usage/main.go
+++ b/cmd/usage/main.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -207,6 +208,11 @@ func run(ctx context.Context, out io.Writer) error {
 		logger.Debug("weirds gotten in report", "node", n)
 	}
 	logger.Debug("run: got report", "report", report)
+
+	enc := json.NewEncoder(out)
+	if err := enc.Encode(report); err != nil {
+		return fmt.Errorf("error encoding report into JSON: %w", err)
+	}
 
 	return err
 }

--- a/cmd/usage/report.go
+++ b/cmd/usage/report.go
@@ -31,8 +31,8 @@ type Kind string
 const (
 	Org   Kind = "cf_org"
 	Space Kind = "cf_space"
-	CfApp Kind = "meter::cfapps"
-	CfSvc Kind = "meter::cfservices"
+	CfApp Kind = "cf_app"
+	CfSvc Kind = "cf_service"
 )
 
 var meterReg = regexp.MustCompile(`^meter::(\w+)`)

--- a/cmd/usage/report.go
+++ b/cmd/usage/report.go
@@ -38,14 +38,21 @@ const (
 var meterReg = regexp.MustCompile(`^meter::(\w+)`)
 
 func (k Kind) String() string {
+	if k.isMeter() {
+		return k.meterName()
+	}
+	return string(k)
+}
+
+func (k Kind) StringRaw() string {
 	return string(k)
 }
 
 func (k Kind) isMeter() bool {
-	res := meterReg.MatchString(k.String())
+	res := meterReg.MatchString(k.StringRaw())
 	return res
 }
 
 func (k Kind) meterName() string {
-	return meterReg.FindStringSubmatch(k.String())[0]
+	return meterReg.FindStringSubmatch(k.StringRaw())[0]
 }

--- a/cmd/usage/report_detail.go
+++ b/cmd/usage/report_detail.go
@@ -6,11 +6,11 @@ type (
 	Report struct {
 		UCreditSum int `json:"microcredit_sum"`
 		ReportLink
-		ReportWriter
+		ReportWriter `json:"-"`
 	}
 	ReportNode struct {
 		UCreditSum int           `json:"microcredit_sum"`
-		Meters     []*ReportLeaf `json:",omitempty"`
+		Meters     []*ReportLeaf `json:"meters,omitempty"`
 		ReportLink
 	}
 	ReportLeaf struct {
@@ -23,10 +23,10 @@ type (
 		root   *Report      `json:"-"`
 		parent ReportLinker `json:"-"`
 
-		Slug  string
-		Path  string
-		Kind  string
-		Nodes []*ReportNode `json:",omitempty"`
+		Slug  string        `json:"slug,omitempty"`
+		Path  string        `json:"path,omitempty"`
+		Kind  string        `json:"kind,omitempty"`
+		Nodes []*ReportNode `json:"nodes,omitempty"`
 	}
 )
 

--- a/cmd/usage/report_detail.go
+++ b/cmd/usage/report_detail.go
@@ -65,13 +65,13 @@ func (rl *ReportLink) setParent(r ReportLinker)    { rl.parent = r }
 
 func (r *Report) SetNode(link ReportLinker, uCredits int, kind any, name, path string) (ReportLinker, error) {
 	var rp rootParenter
-
-	var isLeaf bool
 	var stKind string
 
+	// TODO: meters/leaves are not currently attached
+	// - These are really just the branch tips
+	// - See cloud-gov/cg-interface/cg-billing#89
 	switch k := kind.(type) {
 	case Kind:
-		isLeaf = k.isMeter()
 		stKind = k.String()
 	case string:
 		stKind = k
@@ -79,12 +79,9 @@ func (r *Report) SetNode(link ReportLinker, uCredits int, kind any, name, path s
 		return nil, fmt.Errorf("Report SetNode: kind must be stringable, got: %T", kind)
 	}
 
-	rl := ReportLink{Kind: stKind, Slug: name, Path: path}
-
-	if isLeaf {
-		rp = &ReportLeaf{UCreditUse: uCredits, ReportLink: rl}
-	} else {
-		rp = &ReportNode{UCreditSum: uCredits, ReportLink: rl}
+	rp = &ReportNode{
+		UCreditSum: uCredits,
+		ReportLink: ReportLink{Kind: stKind, Slug: name, Path: path},
 	}
 
 	linker := rp.(ReportLinker)

--- a/cmd/usage/report_detail.go
+++ b/cmd/usage/report_detail.go
@@ -4,28 +4,29 @@ import "fmt"
 
 type (
 	Report struct {
-		UCreditSum int
+		UCreditSum int `json:"microcredit_sum"`
 		ReportLink
 		ReportWriter
 	}
 	ReportNode struct {
-		Path       string
-		Slug       string
-		Kind       string
-		UCreditSum int
-		Meters     []*ReportLeaf
+		UCreditSum int           `json:"microcredit_sum"`
+		Meters     []*ReportLeaf `json:",omitempty"`
 		ReportLink
 	}
 	ReportLeaf struct {
-		Kind       string
-		UCreditUse int
+		UCreditUse int `json:"microcredit_use"`
 		ReportLink
 	}
 	ReportLink struct {
-		parent ReportLinker
-		root   *Report
-		Nodes  []*ReportNode
-		ReportLinker
+		ReportLinker `json:"-"`
+
+		root   *Report      `json:"-"`
+		parent ReportLinker `json:"-"`
+
+		Slug  string
+		Path  string
+		Kind  string
+		Nodes []*ReportNode `json:",omitempty"`
 	}
 )
 
@@ -65,23 +66,34 @@ func (rl *ReportLink) setParent(r ReportLinker)    { rl.parent = r }
 func (r *Report) SetNode(link ReportLinker, uCredits int, kind any, name, path string) (ReportLinker, error) {
 	var rp rootParenter
 
-	if kk, ok := kind.(Kind); ok && kk.isMeter() { // this could also be implicit by excluding a name & path?
-		rp = &ReportLeaf{Kind: kk.meterName(), UCreditUse: uCredits}
-	} else if ok {
-		rp = &ReportNode{Kind: kk.String(), UCreditSum: uCredits, Slug: name, Path: path}
-	} else if ks, ok := kind.(string); ok {
-		rp = &ReportNode{Kind: ks, UCreditSum: uCredits, Slug: name, Path: path}
-	} else {
+	var isLeaf bool
+	var stKind string
+
+	switch k := kind.(type) {
+	case Kind:
+		isLeaf = k.isMeter()
+		stKind = k.String()
+	case string:
+		stKind = k
+	default:
 		return nil, fmt.Errorf("Report SetNode: kind must be stringable, got: %T", kind)
 	}
 
-	rl := rp.(ReportLinker)
-	link.addChild(rl)
+	rl := ReportLink{Kind: stKind, Slug: name, Path: path}
+
+	if isLeaf {
+		rp = &ReportLeaf{UCreditUse: uCredits, ReportLink: rl}
+	} else {
+		rp = &ReportNode{UCreditSum: uCredits, ReportLink: rl}
+	}
+
+	linker := rp.(ReportLinker)
+	link.addChild(linker)
 
 	rp.setRoot(r)
 	rp.setParent(link)
 
-	return rl, nil
+	return linker, nil
 }
 
 func NewReporter() *Report {

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -104,7 +104,7 @@ func handleCreateAppUsageJob(logger *slog.Logger, cf *client.Client, q db.Querie
 			NaturalID:     app.GUID,
 			Meter:         "oneoff",
 			KindNaturalID: "",
-			CFOrgID:       dbx.UtilUUID(space.Relationships.Organization.Data.GUID),
+			CFOrgID:       dbx.ToUUID(space.Relationships.Organization.Data.GUID),
 		})
 		if err != nil {
 			http.Error(w, "upserting resource: "+err.Error(), http.StatusInternalServerError)

--- a/internal/db/cf_org.sql.go
+++ b/internal/db/cf_org.sql.go
@@ -12,15 +12,27 @@ import (
 )
 
 const bulkCreateCFOrgs = `-- name: BulkCreateCFOrgs :exec
-INSERT INTO cf_org (id)
-SELECT DISTINCT id
-FROM UNNEST($1::uuid[]) AS id
-ON CONFLICT DO NOTHING
+INSERT INTO cf_org (id, name)
+SELECT
+  id,
+  name
+FROM
+  UNNEST(
+    $1::uuid[],
+    $2::text[]
+  ) AS o (id, name)
+ON CONFLICT (id) DO UPDATE
+  SET name = excluded.name
 `
 
+type BulkCreateCFOrgsParams struct {
+	Ids   []pgtype.UUID
+	Names []string
+}
+
 // BulkCreateCFOrgs creates CFOrg rows in bulk with the minimum required columns. If a row with the given primary key already exists, that input item is ignored.
-func (q *Queries) BulkCreateCFOrgs(ctx context.Context, ids []pgtype.UUID) error {
-	_, err := q.db.Exec(ctx, bulkCreateCFOrgs, ids)
+func (q *Queries) BulkCreateCFOrgs(ctx context.Context, arg BulkCreateCFOrgsParams) error {
+	_, err := q.db.Exec(ctx, bulkCreateCFOrgs, arg.Ids, arg.Names)
 	return err
 }
 
@@ -55,7 +67,7 @@ func (q *Queries) DeleteCFOrg(ctx context.Context, id pgtype.UUID) error {
 
 const getCFOrg = `-- name: GetCFOrg :one
 SELECT id, name, customer_id FROM cf_org
-WHERE id = $1 LIMIT 1
+WHERE id = $1
 `
 
 func (q *Queries) GetCFOrg(ctx context.Context, id pgtype.UUID) (CFOrg, error) {
@@ -92,7 +104,7 @@ func (q *Queries) ListCFOrgs(ctx context.Context) ([]CFOrg, error) {
 
 const updateCFOrg = `-- name: UpdateCFOrg :exec
 UPDATE cf_org
-  set name = $2
+SET name = $2
 WHERE id = $1
 `
 

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -19,7 +19,7 @@ type Querier interface {
 	// BoundsMonthPrev calculates bounds that encapsulate the month previous to the parameter, as_of. The first bound is inclusive and the second is exclusive.
 	BoundsMonthPrev(ctx context.Context, asOf pgtype.Timestamptz) (BoundsMonthPrevRow, error)
 	// BulkCreateCFOrgs creates CFOrg rows in bulk with the minimum required columns. If a row with the given primary key already exists, that input item is ignored.
-	BulkCreateCFOrgs(ctx context.Context, ids []pgtype.UUID) error
+	BulkCreateCFOrgs(ctx context.Context, arg BulkCreateCFOrgsParams) error
 	BulkCreateMeasurement(ctx context.Context, arg BulkCreateMeasurementParams) error
 	// BulkCreateMeters creates Meter rows in bulk with the minimum required columns. If a row with the given primary key already exists, that input item is ignored.
 	BulkCreateMeters(ctx context.Context, names []string) error

--- a/internal/dbx/utils.go
+++ b/internal/dbx/utils.go
@@ -7,7 +7,14 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
-func UtilUUID(s any) pgtype.UUID {
+func TimeToTimestamp(t time.Time) pgtype.Timestamp {
+	return pgtype.Timestamp{
+		Time:  t,
+		Valid: true,
+	}
+}
+
+func ToUUID(s any) pgtype.UUID {
 	switch s := s.(type) {
 	case pgtype.UUID:
 		return s
@@ -25,9 +32,22 @@ func UtilUUID(s any) pgtype.UUID {
 	return u
 }
 
-func UtilTimestamp(t time.Time) pgtype.Timestamp {
-	return pgtype.Timestamp{
-		Time:  t,
-		Valid: true,
+func ToBlankableUUID(u any) pgtype.UUID {
+	uu := ToUUID(u)
+	if !uu.Valid {
+		if err := uu.Scan("FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF"); err != nil {
+			panic(err)
+		}
 	}
+	return uu
+}
+
+func UUIDishString(u any) string {
+	switch ud := u.(type) {
+	case string:
+		return ud
+	case pgtype.UUID:
+		return ud.String()
+	}
+	return ""
 }

--- a/internal/usage/meter/cfapps.go
+++ b/internal/usage/meter/cfapps.go
@@ -96,7 +96,7 @@ func (m *CFAppMeter) ReadUsage(ctx context.Context) ([]*reader.Measurement, []*n
 		if sidx < 0 {
 			msrmt.Errs = errors.Join(msrmt.Errs, ErrSpaceNotFound)
 			appNode, err := node.New(
-				nil,
+				"",
 				app.GUID,
 				node.WithSlugAuto("app", app.Name),
 				node.WithPathAuto("orphan"),
@@ -109,25 +109,31 @@ func (m *CFAppMeter) ReadUsage(ctx context.Context) ([]*reader.Measurement, []*n
 			return measurements, nodes, nil
 		}
 
+		var org *resource.Organization
+		var orgName string
+		orgID := spaces[sidx].Relationships.Organization.Data.GUID
 		orgIdx := slices.IndexFunc(orgs, func(o *resource.Organization) bool {
-			return o.GUID == spaces[sidx].Relationships.Organization.Data.GUID
+			return o.GUID == orgID
 		})
-		org := orgs[orgIdx]
+		if orgIdx >= 0 && len(orgs) > orgIdx {
+			org = orgs[orgIdx]
+			orgName = org.Name
+		}
 
-		dbOrg, err := m.dbq.GetCFOrg(ctx, dbx.UtilUUID(org.GUID))
+		dbOrg, err := m.dbq.GetCFOrg(ctx, dbx.ToUUID(orgID))
 		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil, fmt.Errorf("ReadUsage: getting org: %w", err)
 		}
 		customerID := dbOrg.CustomerID
 
 		msrmt.CustomerID = customerID
-		msrmt.OrgID = org.GUID
-		msrmt.OrgName = org.Name
+		msrmt.OrgID = orgID
+		msrmt.OrgName = orgName
 
 		cfOrgNode, err := node.New(
 			customerID,
-			org.GUID,
-			node.WithSlugAuto("cforg", org.Name),
+			orgID,
+			node.WithSlugAuto("cforg", orgName),
 			node.WithPathAuto("apps.usage"),
 		)
 		if err != nil {

--- a/internal/usage/meter/cfapps.go
+++ b/internal/usage/meter/cfapps.go
@@ -49,7 +49,7 @@ func (m *CFAppMeter) Name() string {
 	return "cfapps"
 }
 
-func (m *CFAppMeter) ReadUsage(ctx context.Context) ([]reader.Measurement, []*node.Node, error) {
+func (m *CFAppMeter) ReadUsage(ctx context.Context) ([]*reader.Measurement, []*node.Node, error) {
 	m.logger.DebugContext(ctx, "app meter: listing processes")
 	procs, err := m.client.ProcessesList(ctx, client.NewProcessOptions())
 	if err != nil {
@@ -58,12 +58,12 @@ func (m *CFAppMeter) ReadUsage(ctx context.Context) ([]reader.Measurement, []*no
 
 	m.logger.DebugContext(ctx, "app meter: listing apps")
 	appOpts := client.NewAppListOptions() // For fast troubleshooting, set .GUIDs to an app GUID.
-	apps, spaces, err := m.client.AppsListWithSpaces(ctx, appOpts)
+	apps, spaces, orgs, err := m.client.AppsListWithSpacesAndOrgs(ctx, appOpts)
 	if err != nil {
 		return nil, nil, fmt.Errorf("ReadUsage: listing apps w/ spaces: %w", err)
 	}
 
-	measurements := []reader.Measurement{}
+	measurements := []*reader.Measurement{}
 	nodes := []*node.Node{}
 
 	// Aggregate process usage info by app.
@@ -81,17 +81,18 @@ func (m *CFAppMeter) ReadUsage(ctx context.Context) ([]reader.Measurement, []*no
 			continue
 		}
 
-		msrmt := reader.Measurement{
+		msrmt := &reader.Measurement{
 			Meter:             m.Name(),
 			ResourceNaturalID: app.GUID,
 			Value:             appUsage[app.GUID], // In MB. TODO: make sure units align.
 		}
+		measurements = append(measurements, msrmt)
 
 		spaceGUID := app.Relationships.Space.Data.GUID
-
 		sidx := slices.IndexFunc(spaces, func(s *resource.Space) bool {
 			return s.GUID == spaceGUID
 		})
+
 		if sidx < 0 {
 			msrmt.Errs = errors.Join(msrmt.Errs, ErrSpaceNotFound)
 			appNode, err := node.New(
@@ -105,53 +106,55 @@ func (m *CFAppMeter) ReadUsage(ctx context.Context) ([]reader.Measurement, []*no
 			}
 
 			nodes = append(nodes, []*node.Node{appNode}...)
-		} else {
-			cfOrgGUIDString := spaces[sidx].Relationships.Organization.Data.GUID
-			cfOrgGUID := dbx.UtilUUID(cfOrgGUIDString)
-
-			org, err := m.dbq.GetCFOrg(ctx, cfOrgGUID)
-			if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-				return nil, nil, fmt.Errorf("ReadUsage: getting org: %w", err)
-			}
-
-			customerID := org.CustomerID
-			msrmt.CustomerID = customerID
-			msrmt.OrgID = cfOrgGUIDString
-
-			cfOrgNode, err := node.New(
-				customerID,
-				cfOrgGUIDString,
-				node.WithSlugAuto("cforg", org.Name.String),
-				node.WithPathAuto("apps.usage"),
-			)
-			if err != nil {
-				return nil, nil, fmt.Errorf("ReadUsage: creating org node: %w", err)
-			}
-
-			spaceNode, err := node.New(
-				customerID,
-				spaceGUID,
-				node.WithSlugAuto("space", spaces[sidx].Name),
-				node.WithPathByParent(cfOrgNode),
-			)
-			if err != nil {
-				return nil, nil, fmt.Errorf("ReadUsage: creating space node: %w", err)
-			}
-
-			appNode, err := node.New(
-				customerID,
-				app.GUID,
-				node.WithSlugAuto("app", app.Name),
-				node.WithPathByParent(spaceNode),
-			)
-			if err != nil {
-				return nil, nil, fmt.Errorf("ReadUsage: creating app node: %w", err)
-			}
-
-			nodes = append(nodes, []*node.Node{cfOrgNode, spaceNode, appNode}...)
+			return measurements, nodes, nil
 		}
 
-		measurements = append(measurements, msrmt)
+		orgIdx := slices.IndexFunc(orgs, func(o *resource.Organization) bool {
+			return o.GUID == spaces[sidx].Relationships.Organization.Data.GUID
+		})
+		org := orgs[orgIdx]
+
+		dbOrg, err := m.dbq.GetCFOrg(ctx, dbx.UtilUUID(org.GUID))
+		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil, fmt.Errorf("ReadUsage: getting org: %w", err)
+		}
+		customerID := dbOrg.CustomerID
+
+		msrmt.CustomerID = customerID
+		msrmt.OrgID = org.GUID
+		msrmt.OrgName = org.Name
+
+		cfOrgNode, err := node.New(
+			customerID,
+			org.GUID,
+			node.WithSlugAuto("cforg", org.Name),
+			node.WithPathAuto("apps.usage"),
+		)
+		if err != nil {
+			return nil, nil, fmt.Errorf("ReadUsage: creating org node: %w", err)
+		}
+
+		spaceNode, err := node.New(
+			customerID,
+			spaceGUID,
+			node.WithSlugAuto("space", spaces[sidx].Name),
+			node.WithPathByParent(cfOrgNode),
+		)
+		if err != nil {
+			return nil, nil, fmt.Errorf("ReadUsage: creating space node: %w", err)
+		}
+
+		appNode, err := node.New(
+			customerID,
+			app.GUID,
+			node.WithSlugAuto("app", app.Name),
+			node.WithPathByParent(spaceNode),
+		)
+		if err != nil {
+			return nil, nil, fmt.Errorf("ReadUsage: creating app node: %w", err)
+		}
+
+		nodes = append(nodes, []*node.Node{cfOrgNode, spaceNode, appNode}...)
 	}
 
 	return measurements, nodes, nil

--- a/internal/usage/meter/cfapps_test.go
+++ b/internal/usage/meter/cfapps_test.go
@@ -2,6 +2,7 @@ package meter_test
 
 import (
 	"errors"
+	"fmt"
 	"log/slog"
 	"reflect"
 	"testing"
@@ -64,7 +65,7 @@ func mkSpace(guid, orgGUID string) *resource.Space {
 
 // measurementsToMap converts the slice the function returns into a
 // map[appGUID]usage, ignoring zero‑value entries.
-func measurementsToMap(ms []reader.Measurement) map[string]int {
+func measurementsToMap(ms []*reader.Measurement) map[string]int {
 	out := map[string]int{}
 	for _, m := range ms {
 		if m.ResourceNaturalID != "" {
@@ -74,7 +75,7 @@ func measurementsToMap(ms []reader.Measurement) map[string]int {
 	return out
 }
 
-func measurementErrsToMap(ms []reader.Measurement) map[string]error {
+func measurementErrsToMap(ms []*reader.Measurement) map[string]error {
 	out := map[string]error{}
 	for _, m := range ms {
 		if m.ResourceNaturalID != "" {
@@ -101,6 +102,7 @@ func TestCFAppMeter_ReadUsage(t *testing.T) {
 		procs              []*resource.Process
 		apps               []*resource.App
 		spaces             []*resource.Space
+		orgs               []*resource.Organization
 		procErr            error
 		appErr             error
 		want               map[string]int // expected aggregated usage by app GUID
@@ -201,15 +203,17 @@ func TestCFAppMeter_ReadUsage(t *testing.T) {
 				}
 			}()
 
+			fmt.Println("new meter")
 			sut := meter.NewCFAppMeter(
 				slog.Default(),
 				&MockAppMeterCfProvider{
-					Apps: tc.apps, Spaces: tc.spaces, AppErr: tc.appErr,
+					Apps: tc.apps, Spaces: tc.spaces, Orgs: tc.orgs, AppErr: tc.appErr,
 					Processes: tc.procs, ProcErr: tc.procErr,
 				},
 				&StubDbQ{},
 			)
 
+			fmt.Println("read usage")
 			got, _, err := sut.ReadUsage(t.Context())
 			if tc.wantErr && err == nil {
 				t.Fatalf("expected error, got nil")

--- a/internal/usage/meter/cfprovider.go
+++ b/internal/usage/meter/cfprovider.go
@@ -19,14 +19,14 @@ type ServiceMeterCfProvider interface {
 }
 
 type Apps interface {
-	AppsListWithSpaces(context.Context, *client.AppListOptions) ([]*resource.App, []*resource.Space, error)
+	AppsListWithSpacesAndOrgs(context.Context, *client.AppListOptions) ([]*resource.App, []*resource.Space, []*resource.Organization, error)
 }
 type Processes interface {
 	ProcessesList(context.Context, *client.ProcessListOptions) ([]*resource.Process, error)
 }
 
 type Spaces interface {
-	SpacesList(context.Context, *client.SpaceListOptions) ([]*resource.Space, error)
+	SpacesListWithOrgs(context.Context, *client.SpaceListOptions) ([]*resource.Space, []*resource.Organization, error)
 }
 type ServiceInstances interface {
 	ServiceInstancesList(context.Context, *client.ServiceInstanceListOptions) ([]*resource.ServiceInstance, error)
@@ -43,12 +43,20 @@ func (c *CFAdapter) AppsListWithSpaces(ctx context.Context, opts *client.AppList
 	return c.Applications.ListIncludeSpacesAll(ctx, opts)
 }
 
+func (c *CFAdapter) AppsListWithSpacesAndOrgs(ctx context.Context, opts *client.AppListOptions) ([]*resource.App, []*resource.Space, []*resource.Organization, error) {
+	return c.Applications.ListIncludeSpacesAndOrganizationsAll(ctx, opts)
+}
+
 func (c *CFAdapter) ProcessesList(ctx context.Context, opts *client.ProcessListOptions) ([]*resource.Process, error) {
 	return c.Processes.ListAll(ctx, opts)
 }
 
 func (c *CFAdapter) SpacesList(ctx context.Context, opts *client.SpaceListOptions) ([]*resource.Space, error) {
 	return c.Spaces.ListAll(ctx, opts)
+}
+
+func (c *CFAdapter) SpacesListWithOrgs(ctx context.Context, opts *client.SpaceListOptions) ([]*resource.Space, []*resource.Organization, error) {
+	return c.Spaces.ListIncludeOrganizationsAll(ctx, opts)
 }
 
 func (c *CFAdapter) ServiceInstancesList(ctx context.Context, opts *client.ServiceInstanceListOptions) ([]*resource.ServiceInstance, error) {

--- a/internal/usage/meter/cfservices.go
+++ b/internal/usage/meter/cfservices.go
@@ -43,7 +43,7 @@ func (m *CFServiceMeter) Name() string {
 
 // ReadUsage returns the point-in-time usage of services in Cloud Foundry.
 // Returns a non-nil error if there was an error during the overall process of reading usage information from the target system. If individual readings had errors, their errs fields should be set.
-func (m *CFServiceMeter) ReadUsage(ctx context.Context) ([]reader.Measurement, []*node.Node, error) {
+func (m *CFServiceMeter) ReadUsage(ctx context.Context) ([]*reader.Measurement, []*node.Node, error) {
 	m.logger.DebugContext(ctx, "service meter: listing services")
 	opts := client.NewServiceInstanceListOptions()
 	// Ignore user-provided services, which we do not bill for. IMPORTANT: If this is not set, user-provided services will be included. Some response fields that we assume are non-nil, like .Relationships, will be nil on user-provided services. The code below does not guard against this and will panic.
@@ -78,18 +78,27 @@ func (m *CFServiceMeter) ReadUsage(ctx context.Context) ([]reader.Measurement, [
 	type spaceMapItem struct {
 		space *resource.Space
 		org   *resource.Organization
-		dbOrg *db.CFOrg
+		dbOrg db.CFOrg
 	}
 	spaceMap := make(map[string]spaceMapItem, len(spaces))
 	for i, s := range spaces {
 		smi := spaceMapItem{}
-		spaceMap[s.GUID] = smi
-
 		smi.space = s
-		smi.org = orgs[i]
-
+		spaceMap[s.GUID] = smi
 		relOrgID := s.Relationships.Organization.Data.GUID
 
+		dbOrg, err := m.dbq.GetCFOrg(ctx, dbx.ToUUID(relOrgID))
+		if err != nil {
+			if !errors.Is(err, pgx.ErrNoRows) {
+				return nil, nil, err
+			}
+		}
+		smi.dbOrg = dbOrg
+
+		if len(orgs) <= i {
+			continue
+		}
+		smi.org = orgs[i]
 		if smi.org.GUID != relOrgID {
 			m.logger.Error("error: org indices do not match space indices!!",
 				"idx", i,
@@ -97,18 +106,9 @@ func (m *CFServiceMeter) ReadUsage(ctx context.Context) ([]reader.Measurement, [
 				"smiOrgID", smi.org.GUID)
 			smi.org = nil
 		}
-
-		dbOrg, err := m.dbq.GetCFOrg(ctx, dbx.UtilUUID(relOrgID))
-		if err != nil {
-			if !errors.Is(err, pgx.ErrNoRows) {
-				return nil, nil, err
-			}
-		}
-
-		smi.dbOrg = &dbOrg
 	}
 
-	usage := make([]reader.Measurement, len(si))
+	usage := make([]*reader.Measurement, len(si))
 	nodes := make([]*node.Node, 0, len(si)*3)
 
 	m.logger.DebugContext(ctx, "service meter: aggregating services")
@@ -118,10 +118,18 @@ func (m *CFServiceMeter) ReadUsage(ctx context.Context) ([]reader.Measurement, [
 		spaceID := instance.Relationships.Space.Data.GUID
 
 		smi := spaceMap[spaceID]
-		orgID := smi.org.GUID
-		orgName := smi.org.Name
 		spaceName := smi.space.Name
 		customerID := smi.dbOrg.CustomerID
+
+		var orgID, orgName string
+
+		if smi.org != nil {
+			orgID = smi.org.GUID
+			orgName = smi.org.Name
+		} else {
+			orgID = smi.dbOrg.ID.String()
+			orgName = smi.dbOrg.Name.String
+		}
 
 		cfOrgNode, err := node.New(
 			customerID,
@@ -155,7 +163,7 @@ func (m *CFServiceMeter) ReadUsage(ctx context.Context) ([]reader.Measurement, [
 
 		nodes = append(nodes, []*node.Node{cfOrgNode, spaceNode, svcNode}...)
 
-		usage[i] = reader.Measurement{
+		usage[i] = &reader.Measurement{
 			Meter:                 m.Name(),
 			CustomerID:            customerID,
 			OrgID:                 orgID,

--- a/internal/usage/meter/cfservices.go
+++ b/internal/usage/meter/cfservices.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/cloud-gov/billing/internal/db"
+	"github.com/cloud-gov/billing/internal/dbx"
 	"github.com/cloud-gov/billing/internal/usage/node"
 	"github.com/cloud-gov/billing/internal/usage/reader"
 )
@@ -69,30 +70,42 @@ func (m *CFServiceMeter) ReadUsage(ctx context.Context) ([]reader.Measurement, [
 
 	m.logger.DebugContext(ctx, "service meter: listing spaces")
 	spaceopts := client.NewSpaceListOptions()
-	spaces, err := m.client.SpacesList(ctx, spaceopts)
+	spaces, orgs, err := m.client.SpacesListWithOrgs(ctx, spaceopts)
 	if err != nil {
 		return nil, nil, err
 	}
-	// TODO: should maybe just use an indexer?
-	spaceMap := make(map[string]*resource.Space, len(spaces))
-	for _, s := range spaces {
-		spaceMap[s.GUID] = s
-	}
 
-	spacesToOrgs := make(map[string]*db.CFOrg, len(spaces))
-	for _, space := range spaces {
-		orgID := pgtype.UUID{}
-		if err := orgID.Scan(space.Relationships.Organization.Data.GUID); err != nil {
-			return nil, nil, err
+	type spaceMapItem struct {
+		space *resource.Space
+		org   *resource.Organization
+		dbOrg *db.CFOrg
+	}
+	spaceMap := make(map[string]spaceMapItem, len(spaces))
+	for i, s := range spaces {
+		smi := spaceMapItem{}
+		spaceMap[s.GUID] = smi
+
+		smi.space = s
+		smi.org = orgs[i]
+
+		relOrgID := s.Relationships.Organization.Data.GUID
+
+		if smi.org.GUID != relOrgID {
+			m.logger.Error("error: org indices do not match space indices!!",
+				"idx", i,
+				"relOrgID", relOrgID,
+				"smiOrgID", smi.org.GUID)
+			smi.org = nil
 		}
-		org, err := m.dbq.GetCFOrg(ctx, orgID)
+
+		dbOrg, err := m.dbq.GetCFOrg(ctx, dbx.UtilUUID(relOrgID))
 		if err != nil {
 			if !errors.Is(err, pgx.ErrNoRows) {
 				return nil, nil, err
 			}
-			org.ID = orgID // still get an ID if not in our DB
 		}
-		spacesToOrgs[space.GUID] = &org
+
+		smi.dbOrg = &dbOrg
 	}
 
 	usage := make([]reader.Measurement, len(si))
@@ -104,14 +117,16 @@ func (m *CFServiceMeter) ReadUsage(ctx context.Context) ([]reader.Measurement, [
 		offrID := offerMap[planID.Relationships.ServiceOffering.Data.GUID]
 		spaceID := instance.Relationships.Space.Data.GUID
 
-		org := spacesToOrgs[spaceID]
-		orgID := org.ID.String()
-		customerID := org.CustomerID
+		smi := spaceMap[spaceID]
+		orgID := smi.org.GUID
+		orgName := smi.org.Name
+		spaceName := smi.space.Name
+		customerID := smi.dbOrg.CustomerID
 
 		cfOrgNode, err := node.New(
 			customerID,
 			orgID,
-			node.WithSlugAuto("cforg", org.Name.String),
+			node.WithSlugAuto("cforg", orgName),
 			node.WithPathAuto("apps.usage"),
 		)
 		if err != nil {
@@ -121,7 +136,7 @@ func (m *CFServiceMeter) ReadUsage(ctx context.Context) ([]reader.Measurement, [
 		spaceNode, err := node.New(
 			customerID,
 			spaceID,
-			node.WithSlugAuto("space", spaceMap[spaceID].Name),
+			node.WithSlugAuto("space", spaceName),
 			node.WithPathByParent(cfOrgNode),
 		)
 		if err != nil {
@@ -144,6 +159,7 @@ func (m *CFServiceMeter) ReadUsage(ctx context.Context) ([]reader.Measurement, [
 			Meter:                 m.Name(),
 			CustomerID:            customerID,
 			OrgID:                 orgID,
+			OrgName:               orgName,
 			ResourceKindNaturalID: instance.Relationships.ServicePlan.Data.GUID,
 			ResourceNaturalID:     instance.GUID,
 			Value:                 1, // For this type of service, 1 indicates it is present at time of reading

--- a/internal/usage/meter/mocks_test.go
+++ b/internal/usage/meter/mocks_test.go
@@ -34,6 +34,7 @@ type MockAppMeterCfProvider struct {
 	Apps      []*resource.App
 	Spaces    []*resource.Space
 	Processes []*resource.Process
+	Orgs      []*resource.Organization
 	AppErr    error
 	ProcErr   error
 }
@@ -44,6 +45,7 @@ type MockServiceMeterCfProvider struct {
 	Instances []*resource.ServiceInstance
 	Plans     []*resource.ServicePlan
 	Offerings []*resource.ServiceOffering
+	Orgs      []*resource.Organization
 }
 
 func NewMockAppMeterCfProvider() *MockAppMeterCfProvider {
@@ -58,12 +60,20 @@ func (p *MockAppMeterCfProvider) AppsListWithSpaces(_ context.Context, _ *client
 	return p.Apps, p.Spaces, p.AppErr
 }
 
+func (p *MockAppMeterCfProvider) AppsListWithSpacesAndOrgs(_ context.Context, _ *client.AppListOptions) ([]*resource.App, []*resource.Space, []*resource.Organization, error) {
+	return p.Apps, p.Spaces, p.Orgs, p.AppErr
+}
+
 func (p *MockAppMeterCfProvider) ProcessesList(_ context.Context, _ *client.ProcessListOptions) ([]*resource.Process, error) {
 	return p.Processes, p.ProcErr
 }
 
 func (p *MockServiceMeterCfProvider) SpacesList(_ context.Context, _ *client.SpaceListOptions) ([]*resource.Space, error) {
 	return p.Spaces, nil
+}
+
+func (p *MockServiceMeterCfProvider) SpacesListWithOrgs(_ context.Context, _ *client.SpaceListOptions) ([]*resource.Space, []*resource.Organization, error) {
+	return p.Spaces, p.Orgs, nil
 }
 
 func (p *MockServiceMeterCfProvider) ServiceInstancesList(_ context.Context, _ *client.ServiceInstanceListOptions) ([]*resource.ServiceInstance, error) {

--- a/internal/usage/node/node.go
+++ b/internal/usage/node/node.go
@@ -72,17 +72,11 @@ func WithPathByParent(parent *Node) NodeOpt {
 	return WithPathAuto(parent.Path)
 }
 
-func New(customerID any, resourceID string, opts ...NodeOpt) (*Node, error) {
-	n := &Node{ResourceNaturalID: resourceID}
-
-	n.CustomerID = dbx.UtilUUID(customerID)
-	if !n.CustomerID.Valid {
-		err := n.CustomerID.Scan("FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF")
-		if err != nil {
-			panic(err)
-		}
+func New[A, B string | pgtype.UUID](customerID A, resourceID B, opts ...NodeOpt) (*Node, error) {
+	n := &Node{
+		CustomerID:        dbx.ToBlankableUUID(customerID),
+		ResourceNaturalID: dbx.UUIDishString(resourceID),
 	}
-
 	for _, o := range opts {
 		if err := o(n); err != nil {
 			return nil, fmt.Errorf("new node: opts: %w", err)

--- a/internal/usage/reader/reader.go
+++ b/internal/usage/reader/reader.go
@@ -21,6 +21,7 @@ type Reading struct {
 type Measurement struct {
 	CustomerID pgtype.UUID
 	OrgID      string
+	OrgName    string
 	// Meter is the name of the meter which produced this [Measurement].
 	Meter string
 	// ResourceKindNaturalID is the "natural" ID of the Kind of billable resource being measured. The ID is maintained by the external system. For example, the plan ID of a Cloud Foundry service instance. Not all ResourceKinds have a natural ID, so this field may be empty.

--- a/internal/usage/reader/reader.go
+++ b/internal/usage/reader/reader.go
@@ -13,7 +13,7 @@ import (
 // Reading is a point in time at which measurements of billable resources were taken.
 type Reading struct {
 	Time         time.Time
-	Measurements []Measurement
+	Measurements []*Measurement
 	Nodes        []*node.Node
 }
 
@@ -35,7 +35,7 @@ type Measurement struct {
 
 // Meter defines a type that can read usage information from a system containing billable resources, akin to a utility meter.
 type Meter interface {
-	ReadUsage(context.Context) ([]Measurement, []*node.Node, error)
+	ReadUsage(context.Context) ([]*Measurement, []*node.Node, error)
 	Name() string
 }
 
@@ -55,7 +55,7 @@ func (rdr *Reader) Read(ctx context.Context) (Reading, error) {
 	reading := Reading{
 		Time:         time.Now().UTC(),
 		Nodes:        make([]*node.Node, 0),
-		Measurements: make([]Measurement, 0),
+		Measurements: make([]*Measurement, 0),
 	}
 	var reterr error
 

--- a/internal/usage/recorder/recorder.go
+++ b/internal/usage/recorder/recorder.go
@@ -8,7 +8,6 @@ import (
 	"log/slog"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/cloud-gov/billing/internal/db"
 	"github.com/cloud-gov/billing/internal/dbx"
@@ -34,7 +33,7 @@ func RecordReading(ctx context.Context, logger *slog.Logger, q db.Querier, r rea
 	}
 
 	dbMeters := []string{}
-	dbCFOrgs := []pgtype.UUID{}
+	dbCFOrgs := db.BulkCreateCFOrgsParams{}
 	dbKinds := db.BulkCreateResourceKindsParams{}
 	dbResources := db.BulkCreateResourcesParams{}
 	dbResourceNodes := db.BulkCreateResourceNodesParams{}
@@ -51,7 +50,8 @@ func RecordReading(ctx context.Context, logger *slog.Logger, q db.Querier, r rea
 
 		// We may insert thousands of rows at a time. We only want to insert if a row does not already exist. COPY does not support ON CONFLICT, running an INSERT in a loop is inefficient, and sqlc does not support variable-length INSERTs. As a workaround we write INSERT queries that accept arrays, with one array per column where appropriate.
 		dbMeters = append(dbMeters, m.Meter)
-		dbCFOrgs = append(dbCFOrgs, dbx.UtilUUID(m.OrgID))
+		dbCFOrgs.Ids = append(dbCFOrgs.Ids, dbx.UtilUUID(m.OrgID))
+		dbCFOrgs.Names = append(dbCFOrgs.Names, m.OrgName)
 		dbKinds.Meters = append(dbKinds.Meters, m.Meter)
 		dbKinds.NaturalIds = append(dbKinds.NaturalIds, m.ResourceKindNaturalID)
 		dbResources.CfOrgIds = append(dbResources.CfOrgIds, dbx.UtilUUID(m.OrgID))

--- a/internal/usage/recorder/recorder.go
+++ b/internal/usage/recorder/recorder.go
@@ -98,7 +98,7 @@ func RecordReading(ctx context.Context, logger *slog.Logger, q db.Querier, r rea
 	logger.Debug("creating resource nodes in database")
 	err = q.BulkCreateResourceNodes(ctx, dbResourceNodes)
 	if err != nil {
-		return err
+		logger.Error("error in q.BulkCreateResourceNodes", "error", err)
 	}
 	logger.Debug("creating measurements in database")
 	// TODO: For some reason, using q.CreateMeasurements, which is implemented with a COPY, does not work here. It works fine for /usage/app/{guid}.

--- a/internal/usage/recorder/recorder.go
+++ b/internal/usage/recorder/recorder.go
@@ -21,7 +21,7 @@ func RecordReading(ctx context.Context, logger *slog.Logger, q db.Querier, r rea
 	logger.Debug("creating reading in database")
 
 	dbReading, err := q.CreateUniqueReading(ctx, db.CreateUniqueReadingParams{
-		CreatedAt: dbx.UtilTimestamp(r.Time),
+		CreatedAt: dbx.TimeToTimestamp(r.Time),
 		Periodic:  periodic,
 	})
 	if err != nil {
@@ -50,11 +50,11 @@ func RecordReading(ctx context.Context, logger *slog.Logger, q db.Querier, r rea
 
 		// We may insert thousands of rows at a time. We only want to insert if a row does not already exist. COPY does not support ON CONFLICT, running an INSERT in a loop is inefficient, and sqlc does not support variable-length INSERTs. As a workaround we write INSERT queries that accept arrays, with one array per column where appropriate.
 		dbMeters = append(dbMeters, m.Meter)
-		dbCFOrgs.Ids = append(dbCFOrgs.Ids, dbx.UtilUUID(m.OrgID))
+		dbCFOrgs.Ids = append(dbCFOrgs.Ids, dbx.ToUUID(m.OrgID))
 		dbCFOrgs.Names = append(dbCFOrgs.Names, m.OrgName)
 		dbKinds.Meters = append(dbKinds.Meters, m.Meter)
 		dbKinds.NaturalIds = append(dbKinds.NaturalIds, m.ResourceKindNaturalID)
-		dbResources.CfOrgIds = append(dbResources.CfOrgIds, dbx.UtilUUID(m.OrgID))
+		dbResources.CfOrgIds = append(dbResources.CfOrgIds, dbx.ToUUID(m.OrgID))
 		dbResources.KindNaturalIds = append(dbResources.KindNaturalIds, m.ResourceKindNaturalID)
 		dbResources.Meters = append(dbResources.Meters, m.Meter)
 		dbResources.NaturalIds = append(dbResources.NaturalIds, m.ResourceNaturalID)

--- a/internal/usage/recorder/recorder_test.go
+++ b/internal/usage/recorder/recorder_test.go
@@ -23,7 +23,7 @@ type stubQuerier struct {
 
 	createReadingTS pgtype.Timestamp
 	bulkMeters      []string
-	bulkOrgs        []pgtype.UUID
+	bulkOrgs        db.BulkCreateCFOrgsParams
 	bulkKinds       db.BulkCreateResourceKindsParams
 	bulkResources   db.BulkCreateResourcesParams
 	bulkMs          db.BulkCreateMeasurementParams
@@ -60,7 +60,7 @@ func (s *stubQuerier) BulkCreateMeters(_ context.Context, meters []string) error
 	return nil
 }
 
-func (s *stubQuerier) BulkCreateCFOrgs(_ context.Context, orgs []pgtype.UUID) error {
+func (s *stubQuerier) BulkCreateCFOrgs(_ context.Context, orgs db.BulkCreateCFOrgsParams) error {
 	if s.errOn == "BulkCreateCFOrgs" {
 		return ErrExpected
 	}
@@ -192,11 +192,11 @@ func (s *stubQuerier) LQueryResourceNodes(ctx context.Context, arg db.LQueryReso
 	panic("unimplemented")
 }
 
-func (q *stubQuerier) ListResourceNodeAncestors(ctx context.Context, path string) ([]db.ResourceNode, error) {
+func (s *stubQuerier) ListResourceNodeAncestors(ctx context.Context, path string) ([]db.ResourceNode, error) {
 	panic("unimplemented")
 }
 
-func (q *stubQuerier) ListResourceNodeDescendants(ctx context.Context, path string) ([]db.ResourceNode, error) {
+func (s *stubQuerier) ListResourceNodeDescendants(ctx context.Context, path string) ([]db.ResourceNode, error) {
 	panic("unimplemented")
 }
 
@@ -313,14 +313,14 @@ const (
 )
 
 func TestRecordReading(t *testing.T) {
-	goodM := reader.Measurement{
+	goodM := &reader.Measurement{
 		Meter:                 "cpu",
 		OrgID:                 uuid.NewString(),
 		ResourceNaturalID:     "inst-1",
 		ResourceKindNaturalID: "kind-1",
 		Value:                 10,
 	}
-	emptyM := reader.Measurement{}
+	emptyM := &reader.Measurement{}
 
 	cases := []struct {
 		name       string
@@ -340,7 +340,7 @@ func TestRecordReading(t *testing.T) {
 			"only empties",
 			reader.Reading{
 				Time:         time.Now(),
-				Measurements: []reader.Measurement{emptyM},
+				Measurements: []*reader.Measurement{emptyM},
 			},
 			"",
 			NotWanted,
@@ -350,7 +350,7 @@ func TestRecordReading(t *testing.T) {
 			"mixed good+empty",
 			reader.Reading{
 				Time:         time.Now(),
-				Measurements: []reader.Measurement{goodM, emptyM},
+				Measurements: []*reader.Measurement{goodM, emptyM},
 			},
 			"",
 			NotWanted,
@@ -360,7 +360,7 @@ func TestRecordReading(t *testing.T) {
 			"duplicates",
 			reader.Reading{
 				Time:         time.Now(),
-				Measurements: []reader.Measurement{goodM, goodM},
+				Measurements: []*reader.Measurement{goodM, goodM},
 			},
 			"",
 			NotWanted,
@@ -370,7 +370,7 @@ func TestRecordReading(t *testing.T) {
 			"negative value",
 			reader.Reading{
 				Time: time.Now(),
-				Measurements: []reader.Measurement{
+				Measurements: []*reader.Measurement{
 					{
 						Meter:                 "disk",
 						OrgID:                 uuid.NewString(),
@@ -388,7 +388,7 @@ func TestRecordReading(t *testing.T) {
 			"int32 overflow", // we just check that we *didn’t* crash
 			reader.Reading{
 				Time: time.Now(),
-				Measurements: []reader.Measurement{
+				Measurements: []*reader.Measurement{
 					{
 						Meter:                 "ram",
 						OrgID:                 uuid.NewString(),
@@ -406,7 +406,7 @@ func TestRecordReading(t *testing.T) {
 			"bad UUID", // stub makes failure surface at org insert
 			reader.Reading{
 				Time: time.Now(),
-				Measurements: []reader.Measurement{
+				Measurements: []*reader.Measurement{
 					{
 						Meter:                 "net",
 						OrgID:                 "not-a-uuid",
@@ -424,7 +424,7 @@ func TestRecordReading(t *testing.T) {
 			"zero time",
 			reader.Reading{
 				Time:         time.Time{},
-				Measurements: []reader.Measurement{goodM},
+				Measurements: []*reader.Measurement{goodM},
 			},
 			"",
 			NotWanted,
@@ -434,7 +434,7 @@ func TestRecordReading(t *testing.T) {
 			"error on BulkCreateResources",
 			reader.Reading{
 				Time:         time.Now(),
-				Measurements: []reader.Measurement{goodM},
+				Measurements: []*reader.Measurement{goodM},
 			},
 			"BulkCreateResources",
 			ErrWanted,

--- a/sql/queries/cf_org.sql
+++ b/sql/queries/cf_org.sql
@@ -5,7 +5,7 @@ RETURNING *;
 
 -- name: GetCFOrg :one
 SELECT * FROM cf_org
-WHERE id = $1 LIMIT 1;
+WHERE id = $1;
 
 -- name: ListCFOrgs :many
 SELECT * FROM cf_org
@@ -13,7 +13,7 @@ ORDER BY name;
 
 -- name: UpdateCFOrg :exec
 UPDATE cf_org
-  set name = $2
+SET name = $2
 WHERE id = $1;
 
 -- name: DeleteCFOrg :exec
@@ -22,7 +22,14 @@ WHERE id = $1;
 
 -- name: BulkCreateCFOrgs :exec
 -- BulkCreateCFOrgs creates CFOrg rows in bulk with the minimum required columns. If a row with the given primary key already exists, that input item is ignored.
-INSERT INTO cf_org (id)
-SELECT DISTINCT id
-FROM UNNEST(sqlc.arg(ids)::uuid[]) AS id
-ON CONFLICT DO NOTHING;
+INSERT INTO cf_org (id, name)
+SELECT
+  id,
+  name
+FROM
+  UNNEST(
+    sqlc.arg(ids)::uuid[],
+    sqlc.arg(names)::text[]
+  ) AS o (id, name)
+ON CONFLICT (id) DO UPDATE
+  SET name = excluded.name;


### PR DESCRIPTION
## Changes proposed in this pull request:

- better, more correct JSON output
  - idiomatic caps
  - more intelligible names
  - make the false "meters" into report branch _tips_ instead
- resource_node failure resilience, notice above failure
- saving org names when taking measurements

## Security considerations

none
